### PR TITLE
Added missing ops, classes for detailed exceptions, more tests

### DIFF
--- a/src/main/java/refraff/parser/Parser.java
+++ b/src/main/java/refraff/parser/Parser.java
@@ -26,7 +26,10 @@ public class Parser {
 
     // Returns an optional token or emtpy if we've reached the end of tokens
     public Optional<Token> getToken(final int position) {
-        if (position >= 0 && position < tokens.length) {
+        // If we somehow go below position 0, we did something REAL bad in the parser
+        assert(position >= 0);
+
+        if (position < tokens.length) {
             return Optional.of(tokens[position]);
         } else {
             return Optional.empty();
@@ -67,19 +70,22 @@ public class Parser {
         String actualTokenValue = getToken(position).map(Token::toString).orElse("none");
 
         String formattedExceptionMessage = String.format(exceptionMessage, beingParsed, expected, actualTokenValue);
-        throw new ParserException(formattedExceptionMessage);
+        throw new ParserMalformedException(formattedExceptionMessage);
     }
 
     // Attempts to parse token array
     public static Program parseProgram(Token[] tokens) throws ParserException {
         final Parser parser = new Parser(tokens);
         final ParseResult<Program> program = parser.parseProgram(0);
-        if (program.nextPosition == tokens.length) {
-            return program.result;
-        } else {
-            throw new ParserException("Remaining tokens at end, starting with: " +
-                                      parser.getToken(program.nextPosition).toString());
-        }
+        return program.result;
+
+//        If we have more tokens remaining, we will either: parse something successfully, or throw an error
+//        if (program.nextPosition == tokens.length) {
+//            return program.result;
+//        } else {
+//            throw new ParserException("Remaining tokens at end, starting with: " +
+//                                      parser.getToken(program.nextPosition).toString());
+//        }
     }
 
     // program ::= structdef* fdef* stmt*
@@ -110,7 +116,18 @@ public class Parser {
         int currentPosition = position;
 
         while (true) {
-            Optional<ParseResult<T>> optionalParseResult = parseFunction.apply(currentPosition);
+            Optional<ParseResult<T>> optionalParseResult;
+
+            try {
+                optionalParseResult = parseFunction.apply(currentPosition);
+            } catch (ParserMalformedException ex) {
+                // Rethrow a malformed parse
+                throw ex;
+            } catch (ParserNoElementFoundException ex) {
+                // If we didn't find an element, this is completely okay - we are parsing zero or more
+                break;
+            }
+
             if (optionalParseResult.isEmpty()) {
                 break;
             }
@@ -144,7 +161,9 @@ public class Parser {
         }
 
         ParseResult<Type> parsedTypeResult = opStructName.get();
-        StructName structName = ((StructType) parsedTypeResult.result).getStructName().get();
+        StructName structName = ((StructType) parsedTypeResult.result).getStructName()
+                .orElseThrow(() -> new IllegalStateException("Name of struct is somehow not defined from valid identifier."));
+
         currentPosition = parsedTypeResult.nextPosition;
 
         // Ensure that there's a left brace here
@@ -368,6 +387,35 @@ public class Parser {
         );
     }
 
+    public ParseResult<Statement> parseMandatoryStatement(String beingParsed,
+                                                          final int position) throws ParserException {
+        return parseMandatory(beingParsed, "a statement", this::parseStatement, position);
+    }
+
+    private <T> ParseResult<T> parseMandatory(String beingParsed,
+                                              final ParsingFunction<Integer, Optional<ParseResult<T>>> parsingFunction,
+                                              final int position) throws ParserException {
+        return parseMandatory(beingParsed, beingParsed, parsingFunction, position);
+    }
+
+    private <T> ParseResult<T> parseMandatory(String beingParsed, String expected,
+                                              final ParsingFunction<Integer, Optional<ParseResult<T>>> parsingFunction,
+                                              final int position) throws ParserException {
+        try {
+            Optional<ParseResult<T>> optionalParseResult = parsingFunction.apply(position);
+
+            if (optionalParseResult.isEmpty()) {
+                throwParserException(beingParsed, beingParsed, position);
+            }
+
+            return optionalParseResult.get();
+        } catch (ParserNoElementFoundException ex) {
+            throwParserException(beingParsed, beingParsed, position);
+        }
+
+        throw new IllegalStateException("Cannot occur.");
+    }
+
     /*
     stmt ::= type var `=` exp `;` | 
              var `=` exp `;` |
@@ -415,8 +463,8 @@ public class Parser {
             return Optional.of(statementResult);
         }
 
-        // Else return an empty if we found no statements
-        return Optional.empty();
+        // If we couldn't parse any of the statements with supplied parsers, we should throw an exception
+        throw new ParserNoElementFoundException("statement");
     }
 
     // vardec ::= type var '=' exp ';'
@@ -522,10 +570,7 @@ public class Parser {
         Expression condition = parsedCondition.result;
         currentPosition = parsedCondition.nextPosition;
 
-        Optional<ParseResult<Statement>> optionalIfBody = parseStatement(currentPosition);
-        throwParserExceptionOnEmptyOptional("if statement body", optionalIfBody, "a statement", currentPosition);
-
-        ParseResult<Statement> parsedIfBody = optionalIfBody.get();
+        ParseResult<Statement> parsedIfBody = parseMandatoryStatement("if statement body", currentPosition);
 
         Statement ifBody = parsedIfBody.result;
         currentPosition = parsedIfBody.nextPosition;
@@ -538,10 +583,7 @@ public class Parser {
         currentPosition += 1;
 
         // If we did hit an else, the stmt becomes mandatory
-        Optional<ParseResult<Statement>> optionalElseBody = parseStatement(currentPosition);
-        throwParserExceptionOnEmptyOptional("else statement body", optionalElseBody, "a statement", currentPosition);
-
-        ParseResult<Statement> parsedElseBody = optionalElseBody.get();
+        ParseResult<Statement> parsedElseBody = parseMandatoryStatement("else statement body", currentPosition);
 
         Statement elseBody = parsedElseBody.result;
         currentPosition = parsedElseBody.nextPosition;
@@ -555,10 +597,7 @@ public class Parser {
         throwParserExceptionOnUnexpected(where, LeftParenToken.class, "(", position);
         int currentPosition = position + 1;
 
-        Optional<ParseResult<Expression>> optionalParsedExpression = parseExp(currentPosition);
-        throwParserExceptionOnEmptyOptional(where, optionalParsedExpression, "an expression", currentPosition);
-
-        ParseResult<Expression> parsedExpressionResult = optionalParsedExpression.get();
+        ParseResult<Expression> parsedExpressionResult = parseMandatoryExp(currentPosition);
 
         Expression expression = parsedExpressionResult.result;
         currentPosition = parsedExpressionResult.nextPosition;
@@ -586,10 +625,7 @@ public class Parser {
         Expression condition = parsedConditionResult.result;
         currentPosition = parsedConditionResult.nextPosition;
 
-        Optional<ParseResult<Statement>> optionalParsedBody = parseStatement(currentPosition);
-        throwParserExceptionOnEmptyOptional(whileStatement + " body", optionalParsedBody, "a statement", currentPosition);
-
-        ParseResult<Statement> parsedBodyResult = optionalParsedBody.get();
+        ParseResult<Statement> parsedBodyResult = parseMandatoryStatement(whileStatement + " body", currentPosition);
 
         Statement body = parsedBodyResult.result;
         currentPosition = parsedBodyResult.nextPosition;
@@ -650,8 +686,8 @@ public class Parser {
 
             returnValue = parsedReturnValue.result;
             currentPosition = parsedReturnValue.nextPosition;
-        } catch (ParserException ex) {
-            // If we have a parser exception, we couldn't parse the exp that was optional (this is okay)
+        } catch (ParserNoElementFoundException ex) {
+            // If we have a parser no element found, we couldn't parse the exp that was optional (this is okay)
         }
 
         throwParserExceptionOnNoSemicolon("return statement", currentPosition);
@@ -672,7 +708,7 @@ public class Parser {
         List<Statement> blockBody = new ArrayList<>();
         currentPosition = parseZeroOrMore(this::parseStatement, blockBody::add, currentPosition);
 
-        throwParserExceptionOnUnexpected("statement block", RightBraceToken.class, "}", currentPosition);
+        throwParserExceptionOnUnexpected("statement body", RightBraceToken.class, "}", currentPosition);
         currentPosition += 1;
 
         return Optional.of(new ParseResult<>(new StmtBlock(blockBody), currentPosition));
@@ -683,16 +719,22 @@ public class Parser {
         Expression expression;
         int currentPosition;
 
-        try {
-            Optional<ParseResult<Expression>> optionalParsedExpression = parseExp(position);
-            ParseResult<Expression> parsedExpression = optionalParsedExpression.get();
+        Optional<ParseResult<Expression>> optionalParsedExpression;
 
-            expression = parsedExpression.result;
-            currentPosition = parsedExpression.nextPosition;
-        } catch (ParserException ex) {
-            // If we don't have an expression that we parsed, this is okay - we might not need to parse a statement
+        try {
+           optionalParsedExpression = parseExp(position);
+        } catch (ParserMalformedException ex) {
+            // If our result was malformed, we should rethrow the exception
+            throw ex;
+        } catch (ParserNoElementFoundException ex) {
+            // If we could not parse, treat this as okay and let the caller handle it
             return Optional.empty();
         }
+
+        ParseResult<Expression> parsedExpression = optionalParsedExpression.get();
+
+        expression = parsedExpression.result;
+        currentPosition = parsedExpression.nextPosition;
 
         throwParserExceptionOnNoSemicolon("expression statement", currentPosition);
         currentPosition += 1;
@@ -707,13 +749,19 @@ public class Parser {
         new SimpleImmutableEntry<>(new NotEqualsToken(), OperatorEnum.NOT_EQUALS),
         new SimpleImmutableEntry<>(new LessThanEqualsToken(), OperatorEnum.LESS_THAN_EQUALS),
         new SimpleImmutableEntry<>(new GreaterThanEqualsToken(), OperatorEnum.GREATER_THAN_EQUALS),
+        new SimpleImmutableEntry<>(new LessThanToken(), OperatorEnum.LESS_THAN),
+        new SimpleImmutableEntry<>(new GreaterThanToken(), OperatorEnum.GREATER_THAN),
         new SimpleImmutableEntry<>(new PlusToken(), OperatorEnum.PLUS),
         new SimpleImmutableEntry<>(new MinusToken(), OperatorEnum.MINUS),
         new SimpleImmutableEntry<>(new MultiplyToken(), OperatorEnum.MULTIPLY),
         new SimpleImmutableEntry<>(new DivisionToken(), OperatorEnum.DIVISION),
         new SimpleImmutableEntry<>(new NotToken(), OperatorEnum.NOT),
         new SimpleImmutableEntry<>(new DotToken(), OperatorEnum.DOT)
-    );    
+    );
+
+    public ParseResult<Expression> parseMandatoryExp(final int position) throws ParserException {
+        return parseMandatory("an expression", this::parseExp, position);
+    }
 
     // exp ::= or_exp
     public Optional<ParseResult<Expression>> parseExp(final int position) throws ParserException {
@@ -732,10 +780,11 @@ public class Parser {
         // Try to parse a lower precedence expression
         Optional<ParseResult<Expression>> returnValue = parseLowerPrecedence.apply(currentPosition);
         throwParserExceptionOnEmptyOptional(subExpressionName, returnValue, "an expression", currentPosition);
+
         currentPosition = returnValue.get().nextPosition;
 
         // See if there is an expected operator for this level
-        while(isValidOperatorToken(currentPosition, validOperatorClasses)) {
+        while (isValidOperatorToken(currentPosition, validOperatorClasses)) {
             // Get the operator
             OperatorEnum op = TOKEN_TO_OP.get(getToken(currentPosition).get());
             currentPosition += 1;
@@ -749,6 +798,7 @@ public class Parser {
             returnValue = Optional.of(new ParseResult<Expression>(binOpExp, rightExp.get().nextPosition));
             currentPosition = returnValue.get().nextPosition;
         }
+
         return returnValue;
     }
 
@@ -759,6 +809,7 @@ public class Parser {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -891,28 +942,35 @@ public class Parser {
             return optionalPrimaryExp;
         }
 
-        // Then try to parse int, bool, var or null
         // Get the token
         final Optional<Token> maybeToken = getToken(position);
         if (maybeToken.isEmpty()) {
-            return Optional.empty();
+            throw new ParserNoElementFoundException("primary expression");
         }
 
         Token token = maybeToken.get();
         Class<? extends Token> tokenClass = token.getClass();
 
-        if (!TOKEN_TO_PRIMARY.containsKey(tokenClass)) {
-            // Then try to parse struct allocation
-            optionalPrimaryExp = parseStructAlloc(position);
-            if (!optionalPrimaryExp.isEmpty()) {
-                return optionalPrimaryExp;
-            }
-            // Else it must be a parenthesitized expression
-            return parseParenExp(position);
+        // Then try to parse int, bool, var or null
+        if (TOKEN_TO_PRIMARY.containsKey(tokenClass)) {
+            Expression exp = TOKEN_TO_PRIMARY.get(tokenClass).apply(token);
+            return Optional.of(new ParseResult<>(exp, position + 1));
         }
 
-        Expression exp = TOKEN_TO_PRIMARY.get(tokenClass).apply(token);
-        return Optional.of(new ParseResult<>(exp, position + 1));
+        // Then try to parse struct allocation
+        optionalPrimaryExp = parseStructAlloc(position);
+        if (!optionalPrimaryExp.isEmpty()) {
+            return optionalPrimaryExp;
+        }
+
+        // Then try a parenthesitized expression
+        optionalPrimaryExp = parseParenExp(position);
+        if (optionalPrimaryExp.isPresent()) {
+            return optionalPrimaryExp;
+        }
+
+        // We could not find a matching primary expression, and what even could it be?
+        throw new ParserNoElementFoundException("primary expression");
     }
 
     // `new` structname `{` struct_actual_params `}`
@@ -923,10 +981,19 @@ public class Parser {
         // Try to parse a new token
         if (isExpectedToken(currentPosition, NewToken.class)) {
             currentPosition += 1;
-            // Get the structName - hrow exceptions after this point
-            Optional<ParseResult<Type>> optionalStructName = parseType(currentPosition);
-            throwParserExceptionOnEmptyOptional(structAllocString, optionalStructName, "struct name", currentPosition);
-            currentPosition = optionalStructName.get().nextPosition;
+            // Get the structName - throw exceptions after this point
+            Optional<ParseResult<Type>> optionalParsedType = parseType(currentPosition);
+            throwParserExceptionOnEmptyOptional(structAllocString, optionalParsedType, "struct name", currentPosition);
+
+            ParseResult<Type> parsedTypeResult = optionalParsedType.get();
+            Type parsedType = parsedTypeResult.result;
+
+            if (!(parsedType instanceof StructType)) {
+                throwParserException("struct allocation", "a struct name for initialization", position);
+            }
+
+            StructType structType = (StructType) parsedType;
+            currentPosition = optionalParsedType.get().nextPosition;
 
             // Skip the left brace
             throwParserExceptionOnUnexpected(structAllocString, LeftBraceToken.class, "left brace {", currentPosition);
@@ -943,7 +1010,7 @@ public class Parser {
             // Create and return struct alloc
             return Optional.of(
                 new ParseResult<Expression>(
-                    new StructAllocExp(optionalStructName.get().result, structActParams.result),
+                    new StructAllocExp(structType, structActParams.result),
                     currentPosition
                 )
             );
@@ -1017,10 +1084,13 @@ public class Parser {
     // `(` exp `)`
     public Optional<ParseResult<Expression>> parseParenExp(final int position) throws ParserException {
         String parenExpString = "primary parenthesitized expression";
-        int currentPosition = position;
-        // There should be a left paren here
-        throwParserExceptionOnUnexpected(parenExpString, LeftParenToken.class, "left paren (", currentPosition);
-        currentPosition += 1;
+
+        if (!isExpectedToken(position, LeftParenToken.class)) {
+            return Optional.empty();
+        }
+
+        // There was a left paren here
+        int currentPosition = position + 1;
 
         // Try to parse expression
         Optional<ParseResult<Expression>> optionalExpression = parseExp(currentPosition);

--- a/src/main/java/refraff/parser/ParserMalformedException.java
+++ b/src/main/java/refraff/parser/ParserMalformedException.java
@@ -1,0 +1,10 @@
+package refraff.parser;
+
+// Thrown when a parser finds something that is explicitly malformed
+public class ParserMalformedException extends ParserException {
+
+    public ParserMalformedException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/refraff/parser/ParserNoElementFoundException.java
+++ b/src/main/java/refraff/parser/ParserNoElementFoundException.java
@@ -1,0 +1,10 @@
+package refraff.parser;
+
+// Thrown when a parser cannot find the specific type
+public class ParserNoElementFoundException extends ParserException {
+
+    public ParserNoElementFoundException(String message) {
+        super("Parser exception: " + message + " could not be parsed");
+    }
+
+}

--- a/src/main/java/refraff/parser/expression/primaryExpression/StructAllocExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/StructAllocExp.java
@@ -1,6 +1,6 @@
 package refraff.parser.expression.primaryExpression;
 
-import refraff.parser.type.Type;
+import refraff.parser.type.StructType;
 import refraff.parser.struct.StructActualParams;
 
 
@@ -8,17 +8,17 @@ public class StructAllocExp extends PrimaryExpression {
         
     private static final String STRUCT_ALLOC_EXP = "struct allocation expression";
 
-    private final Type structName;
+    private final StructType structType;
     private final StructActualParams params;
 
-    public StructAllocExp(Type structName, StructActualParams params) {
+    public StructAllocExp(StructType structType, StructActualParams params) {
         super(STRUCT_ALLOC_EXP);
-        this.structName = structName;
+        this.structType = structType;
         this.params = params;
     }
 
-    public Type getStructName() {
-        return structName;
+    public StructType getStructType() {
+        return structType;
     }
 
     public StructActualParams getParams() {

--- a/src/main/java/refraff/parser/operator/OperatorEnum.java
+++ b/src/main/java/refraff/parser/operator/OperatorEnum.java
@@ -7,6 +7,8 @@ public enum OperatorEnum {
     NOT_EQUALS("!="),
     LESS_THAN_EQUALS("<="),
     GREATER_THAN_EQUALS(">="),
+    LESS_THAN("<"),
+    GREATER_THAN(">"),
     PLUS("+"),
     MINUS("-"),
     MULTIPLY("*"),

--- a/src/test/java/refraff/parser/ParserTest.java
+++ b/src/test/java/refraff/parser/ParserTest.java
@@ -477,6 +477,36 @@ public class ParserTest {
                 parser.parseProgram(0));
     }
 
+    private void testCompareExpWithOperator(OperatorEnum operator, Token tokenOperator) {
+        // 3 <op> 4;
+        Token[] input = toArray(new IntLiteralToken("3"), tokenOperator, new IntLiteralToken("4"), new SemicolonToken());
+
+        BinaryOpExp binaryOpExp = new BinaryOpExp(new IntLiteralExp(3), operator, new IntLiteralExp(4));
+        ExpressionStmt expressionStmt = new ExpressionStmt(binaryOpExp);
+
+        testStatementMatchesExpected(expressionStmt, input);
+    }
+
+    @Test
+    public void testCompareExpWithLessThanEquals() {
+        testCompareExpWithOperator(OperatorEnum.LESS_THAN_EQUALS, new LessThanEqualsToken());
+    }
+
+    @Test
+    public void testCompareExpWithGreaterThanEquals() {
+        testCompareExpWithOperator(OperatorEnum.GREATER_THAN_EQUALS, new GreaterThanEqualsToken());
+    }
+
+    @Test
+    public void testCompareExpWithLessThan() {
+        testCompareExpWithOperator(OperatorEnum.LESS_THAN, new LessThanToken());
+    }
+
+    @Test
+    public void testCompareExpWithGreaterThan() {
+        testCompareExpWithOperator(OperatorEnum.GREATER_THAN, new GreaterThanToken());
+    }
+
     @Test
     public void testParseStatementWithDifferentOperatorPrecedence() {
         /*
@@ -521,6 +551,28 @@ public class ParserTest {
         testStatementMatchesExpected(statement, input);
     }
 
+    @Test
+    public void testStructDefWithNoParams() {
+        // struct A {}
+        Token[] input = toArray(new StructToken(), new IdentifierToken("a"), new LeftBraceToken(), new RightBraceToken());
+        StructDef structDef = new StructDef(new StructName("a"), List.of());
+        Program program = new Program(List.of(structDef), List.of(), List.of());
+
+        testProgramMatchesExpectedResult(program, input);
+    }
+
+    @Test
+    public void testStructAllocationWithNoParams() {
+        // new A {};
+        Token[] input = toArray(new NewToken(), new IdentifierToken("A"), new LeftBraceToken(), new RightBraceToken(),
+                new SemicolonToken());
+
+        StructAllocExp structAllocExp = new StructAllocExp(new StructType(new StructName("A")),
+                new StructActualParams(List.of()));
+        ExpressionStmt expressionStmt = new ExpressionStmt(structAllocExp);
+
+        testStatementMatchesExpected(expressionStmt, input);
+    }
 
     @Test
     public void testParseProgramWithStructAllocation() throws ParserException {
@@ -657,9 +709,17 @@ public class ParserTest {
                 parser.parseProgram(0));
     }
 
+    // Invalid tests
 
     private void testProgramParsesWithException(Token... tokens) {
-        assertThrows(ParserException.class, () -> parseProgram(tokens));
+        assertThrows(ParserMalformedException.class, () -> parseProgram(tokens));
+    }
+
+    @Test
+    public void testStructDefWithNoParamNameThrowsException() {
+        // struct A { int; }
+        testProgramParsesWithException(new StructToken(), new IdentifierToken("A"), new LeftBraceToken(),
+                new IntToken(), new SemicolonToken(), new RightBraceToken());
     }
 
     @Test
@@ -842,6 +902,13 @@ public class ParserTest {
             new StructToken(), new AssignmentToken(), new LeftBraceToken(),
             new RightBraceToken(), new SemicolonToken()
         );
+    }
+
+    @Test
+    public void testStructAllocationWithIntTokenInsteadOfStructNameThrowsException() {
+        // new int {};
+        testProgramParsesWithException(new NewToken(), new IntToken(), new LeftBraceToken(), new RightBraceToken(),
+                new SemicolonToken());
     }
 
     @Test


### PR DESCRIPTION
The following is what are included:
- Added unit tests for coverage of missed branches
- Added LessThan and GreaterThan ops
  - When unit testing for coverage, I found these were missing
- Added two new types of exceptions:
  - ParserMalformedException - something we know we should parse is malformed in some way
  - ParserNoElementFoundException - we couldn't figure out what we should be parsing (as an expression or statement), and were not able to parse something

In regards to the exceptions, I was encountering an issue in `parseExpressionStatement`. If I failed to parse an expression, then that could have failed either because 1) the expression was malformed or 2) we have absolutely no idea what expression should have been parsed. Case 2) is theoretically okay, because we don't always need to parse an expression statement. For case 1), that is not okay - the expression we know we needed to parse was definitely wrong in some way. When adding more coverage, these edge cases became much more of an issue.

Adding the two exception classes allows us to explicitly catch the case we want. So if we parse no statements on a `stmt*`, we can catch the NoElementFoundException and be okay; but if we run into a malformed statement, that is no longer okay and is much easier to manage. The same goes for parsing an expression which may be optional.

I got the coverage up to 97% with the parser. The missing stuff is all exceptions that are thrown which Jacoco does not pick up. This should wrap up the parser completely and hopefully limit the amount of errors we'll experience when doing the typechecker!