### PR TITLE
Typechecker

### DIFF
--- a/src/main/java/refraff/Source.java
+++ b/src/main/java/refraff/Source.java
@@ -109,8 +109,8 @@ public class Source {
     public String toString() {
         return String.format(
                 "%s to %s: `%s`",
-                getStartPosition().toLinePosition(true),
-                getEndPosition().toLinePosition(false),
+                getStartPosition().toLinePosition(false),
+                getEndPosition().toLinePosition(true),
                 getSourceString()
         );
     }

--- a/src/main/java/refraff/Source.java
+++ b/src/main/java/refraff/Source.java
@@ -1,0 +1,118 @@
+package refraff;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class Source {
+
+    public static final Source DEFAULT_TESTING_SOURCE = new Source(
+            "",
+            SourcePosition.DEFAULT_SOURCE_POSITION,
+            SourcePosition.DEFAULT_SOURCE_POSITION
+    );
+
+    private final String sourceString;
+    private final SourcePosition startPosition;
+    private final SourcePosition endPosition;
+
+    public Source(String sourceString, SourcePosition startPosition, SourcePosition endPosition) {
+        this.sourceString = sourceString;
+
+        this.startPosition = startPosition;
+        this.endPosition = endPosition;
+    }
+
+    public String getSourceString() {
+        return sourceString;
+    }
+
+    public SourcePosition getStartPosition() {
+        return startPosition;
+    }
+
+    public SourcePosition getEndPosition() {
+        return endPosition;
+    }
+
+    public String toPositionString() {
+        // Special case: our lines are the same
+        if (startPosition.getLinePosition() == endPosition.getLinePosition()) {
+            String edgeFormat = "line %d, columns %d to %d";
+            return String.format(edgeFormat, startPosition.getLinePosition(), startPosition.getColumnPosition(),
+                    // Our end column position is exclusive
+                    endPosition.getColumnPosition() - 1);
+        }
+
+        String multilineFormat = "%s to %s";
+        return String.format(multilineFormat, startPosition.toLinePosition(false), endPosition.toLinePosition(true));
+    }
+
+    public static Source fromSources(Source... sources) {
+        return fromSources(Arrays.asList(sources));
+    }
+
+    public static Source fromSources(List<Source> sources) {
+        int numberOfSources = sources.size();
+
+        if (numberOfSources == 0) {
+            throw new IllegalArgumentException("Source list must not be empty.");
+        }
+
+        if (numberOfSources == 1) {
+            return sources.get(0);
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        Source previous = sources.get(0);
+        stringBuilder.append(previous.getSourceString());
+
+        for (int i = 1; i < sources.size(); i++) {
+            Source source = sources.get(i);
+
+            SourcePosition previousEndPosition = previous.getEndPosition();
+            SourcePosition currentStartPosition = source.getStartPosition();
+
+            SourcePosition spaceSeparators = currentStartPosition.getSpaceSeparators(previousEndPosition);
+
+            // Add back the spacing we eliminated previously
+            stringBuilder.append("\n".repeat(Math.max(0, spaceSeparators.getLinePosition())));
+            stringBuilder.append(" ".repeat(Math.max(0, spaceSeparators.getColumnPosition())));
+
+            stringBuilder.append(source.getSourceString());
+            previous = source;
+        }
+
+        String collectiveSourceString = stringBuilder.toString();
+
+        SourcePosition startPosition = sources.get(0).getStartPosition();
+        SourcePosition endPosition = sources.get(numberOfSources - 1).getEndPosition();
+
+        return new Source(collectiveSourceString, startPosition, endPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getSourceString(), getStartPosition(), getEndPosition());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof Source otherSource
+                && Objects.equals(getSourceString(), otherSource.getSourceString())
+                && Objects.equals(getStartPosition(), otherSource.getStartPosition())
+                && Objects.equals(getEndPosition(), otherSource.getEndPosition());
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%s to %s: `%s`",
+                getStartPosition().toLinePosition(true),
+                getEndPosition().toLinePosition(false),
+                getSourceString()
+        );
+    }
+
+}

--- a/src/main/java/refraff/SourcePosition.java
+++ b/src/main/java/refraff/SourcePosition.java
@@ -1,0 +1,65 @@
+package refraff;
+
+import java.util.Objects;
+
+public class SourcePosition {
+
+    public static final int STARTING_LINE_POSITION = 1;
+    public static final int STARTING_COLUMN_POSITION = 1;
+
+    public static final SourcePosition DEFAULT_SOURCE_POSITION = new SourcePosition(
+            STARTING_LINE_POSITION,
+            STARTING_COLUMN_POSITION
+    );
+
+    private final int linePosition;
+    private final int columnPosition;
+
+    public SourcePosition(int linePosition, int columnPosition) {
+        this.linePosition = linePosition;
+        this.columnPosition = columnPosition;
+    }
+
+    public int getLinePosition() {
+        return linePosition;
+    }
+
+    public int getColumnPosition() {
+        return columnPosition;
+    }
+
+    public SourcePosition getSpaceSeparators(SourcePosition other) {
+        if (getLinePosition() == other.getLinePosition()) {
+            return new SourcePosition(0, Math.abs(getColumnPosition() - other.getColumnPosition()));
+        }
+
+        // We start counting at 1, so take away that first "space" that should be added
+        int columnPosition = getLinePosition() > other.getLinePosition() ? getColumnPosition() : other.getColumnPosition();
+        columnPosition -= 1;
+
+        return new SourcePosition(Math.abs(getLinePosition() - other.getLinePosition()), columnPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLinePosition(), getColumnPosition());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof SourcePosition otherPosition
+                && getLinePosition() == otherPosition.getLinePosition()
+                && getColumnPosition() == otherPosition.getColumnPosition();
+    }
+
+    public String toLinePosition(boolean isEndPosition) {
+        int columnPosition = isEndPosition ? getColumnPosition() - 1 : getColumnPosition();
+        return String.format("line %d, column %d", getLinePosition(), columnPosition);
+    }
+
+    @Override
+    public String toString() {
+        return toLinePosition(false);
+    }
+
+}

--- a/src/main/java/refraff/Sourceable.java
+++ b/src/main/java/refraff/Sourceable.java
@@ -1,0 +1,7 @@
+package refraff;
+
+public interface Sourceable {
+
+    Source getSource();
+
+}

--- a/src/main/java/refraff/Sourced.java
+++ b/src/main/java/refraff/Sourced.java
@@ -1,0 +1,41 @@
+package refraff;
+
+import java.util.Objects;
+
+public class Sourced<T> implements Sourceable {
+
+    private final Source source;
+    private final T t;
+
+    public Sourced(Source source, T t) {
+        this.source = source;
+        this.t = t;
+    }
+
+    @Override
+    public Source getSource() {
+        return source;
+    }
+
+    public T getValue() {
+        return this.t;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof Sourced otherSourced
+                && Objects.equals(getSource(), otherSourced.getSource())
+                && Objects.equals(getValue(), otherSourced.getValue());
+    }
+
+    @Override
+    public String toString() {
+        return source.getSourceString() + " at " + source.toPositionString();
+    }
+
+}

--- a/src/main/java/refraff/parser/AbstractSyntaxTreeNode.java
+++ b/src/main/java/refraff/parser/AbstractSyntaxTreeNode.java
@@ -5,7 +5,7 @@ import refraff.Sourceable;
 
 import java.util.Objects;
 
-public abstract class AbstractSyntaxTreeNode implements Node, Sourceable {
+public abstract class AbstractSyntaxTreeNode implements Node {
 
     private static final String TO_STRING_FORMAT = "Node %s sourced from %s contains value `%s`";
 
@@ -26,13 +26,16 @@ public abstract class AbstractSyntaxTreeNode implements Node, Sourceable {
         return this.source;
     }
 
-    public void setSource(Source source) throws IllegalStateException {
+    @Override
+    public Node setSource(Source source) throws IllegalStateException {
         if (hasSourceBeenSet) {
             throw new IllegalStateException("This source has already been set.");
         }
 
         this.hasSourceBeenSet = true;
         this.source = source;
+
+        return this;
     }
 
     @Override

--- a/src/main/java/refraff/parser/AbstractSyntaxTreeNode.java
+++ b/src/main/java/refraff/parser/AbstractSyntaxTreeNode.java
@@ -1,33 +1,54 @@
 package refraff.parser;
 
-public abstract class AbstractSyntaxTreeNode implements Node {
+import refraff.Source;
+import refraff.Sourceable;
 
-    /*
-        * Format for printing the token nicely: "<descriptor> '<tokenizedValue>'"
-        * e.g. "Variable 'counter'"
-        * "Type 'int'"
-        * "Statement 'Variable declaration'"
-        * "int literal expression 6"
-        * 
-        * This may be more useful when debugging the compiler and getting helpful error
-        * messages.
-     */
-    private static final String TO_STRING_FORMAT = "%s '%s'";
+import java.util.Objects;
 
-    private final String parsedValue;
+public abstract class AbstractSyntaxTreeNode implements Node, Sourceable {
 
-    public AbstractSyntaxTreeNode(String parsedValue) {
-        this.parsedValue = parsedValue;
+    private static final String TO_STRING_FORMAT = "Node %s sourced from %s contains value `%s`";
+
+    private final String nodeTypeDescriptor;
+
+    private Source source;
+    private boolean hasSourceBeenSet;
+
+    public AbstractSyntaxTreeNode(String nodeTypeDescriptor) {
+        this.nodeTypeDescriptor = nodeTypeDescriptor;
+
+        this.source = Source.DEFAULT_TESTING_SOURCE;
+        this.hasSourceBeenSet = false;
+    }
+
+    @Override
+    public Source getSource() {
+        return this.source;
+    }
+
+    public void setSource(Source source) throws IllegalStateException {
+        if (hasSourceBeenSet) {
+            throw new IllegalStateException("This source has already been set.");
+        }
+
+        this.hasSourceBeenSet = true;
+        this.source = source;
     }
 
     @Override
     public String getParsedValue() {
-        return this.parsedValue;
+        return source.getSourceString();
+    }
+
+    @Override
+    public String getNodeTypeDescriptor() {
+        return this.nodeTypeDescriptor;
     }
 
     @Override
     public String toString() {
-        return String.format(TO_STRING_FORMAT, getNodeTypeDescriptor(), getParsedValue());
+        return String.format(TO_STRING_FORMAT, getNodeTypeDescriptor(), source.toPositionString(),
+                source.getSourceString());
     }
 
     @Override
@@ -37,7 +58,7 @@ public abstract class AbstractSyntaxTreeNode implements Node {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof AbstractSyntaxTreeNode otherToken 
-        && getParsedValue().equals(otherToken.getParsedValue());
+        return other instanceof AbstractSyntaxTreeNode otherNode
+                && Objects.equals(getSource(), otherNode.getSource());
     }
 }

--- a/src/main/java/refraff/parser/Node.java
+++ b/src/main/java/refraff/parser/Node.java
@@ -1,6 +1,10 @@
 package refraff.parser;
 
-public interface Node {
+import refraff.Source;
+import refraff.SourcePosition;
+import refraff.Sourceable;
+
+public interface Node extends Sourceable {
     /**
      * A description of the nodes's type. For example, 'int type' or 'plus operator'.
      *
@@ -14,5 +18,22 @@ public interface Node {
      * @return the string that was obtained by the parser
      */
     String getParsedValue();
+
+    Node setSource(Source source) throws IllegalStateException;
+
+    @SuppressWarnings("unchecked")
+    static <T extends Node> T setNodeSource(T t, String sourceString) {
+        return (T) t.setSource(
+                new Source(
+                        sourceString,
+                        SourcePosition.DEFAULT_SOURCE_POSITION,
+                        SourcePosition.DEFAULT_SOURCE_POSITION)
+                );
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends Node> T setNodeSource(T t, Source source) {
+        return (T) t.setSource(source);
+    }
 
 }

--- a/src/main/java/refraff/parser/Parser.java
+++ b/src/main/java/refraff/parser/Parser.java
@@ -1177,8 +1177,7 @@ public class Parser {
     private static final Map<Class<? extends Token>, Function<Token, Type>> TOKEN_CLASS_TO_TYPE = Map.of(
             IntToken.class, (token) -> new IntType(),
             BoolToken.class, (token) -> new BoolType(),
-            VoidToken.class, (token) -> new VoidType(),
-            IdentifierToken.class, (token) -> new StructType(new StructName(token.getTokenizedValue()))
+            VoidToken.class, (token) -> new VoidType()
     );
 
     // type ::= 'int' | 'bool' | 'void' | structname
@@ -1186,6 +1185,12 @@ public class Parser {
         final Optional<Token> maybeToken = getToken(position);
         if (maybeToken.isEmpty()) {
             return Optional.empty();
+        }
+
+        // Explicitly handle identifiers to source both the struct name and struct type
+        if (isExpectedToken(position, IdentifierToken.class)) {
+            StructName structName = getSourcedNode(position, token -> new StructName(token.getTokenizedValue()));
+            return getOptionalSourcedParseResult(new StructType(structName), position, position + 1);
         }
 
         Token token = maybeToken.get();

--- a/src/main/java/refraff/parser/Parser.java
+++ b/src/main/java/refraff/parser/Parser.java
@@ -5,6 +5,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.AbstractMap.SimpleImmutableEntry;
 
+import refraff.Source;
+import refraff.Sourced;
 import refraff.parser.function.*;
 import refraff.parser.statement.*;
 import refraff.parser.struct.*;
@@ -18,10 +20,10 @@ import refraff.tokenizer.*;
 
 public class Parser {
     
-    public final Token[] tokens;
+    public final List<Sourced<Token>> sourcedTokens;
 
-    public Parser(final Token[] tokens) {
-        this.tokens = tokens;
+    public Parser(final List<Sourced<Token>> sourcedTokens) {
+        this.sourcedTokens = sourcedTokens;
     }
 
     // Returns an optional token or emtpy if we've reached the end of tokens
@@ -29,8 +31,8 @@ public class Parser {
         // If we somehow go below position 0, we did something REAL bad in the parser
         assert(position >= 0);
 
-        if (position < tokens.length) {
-            return Optional.of(tokens[position]);
+        if (position < sourcedTokens.size()) {
+            return Optional.of(sourcedTokens.get(position).getValue());
         } else {
             return Optional.empty();
         }
@@ -66,15 +68,22 @@ public class Parser {
     }
 
     private void throwParserException(String beingParsed, String expected, int position) throws ParserException {
-        final String exceptionMessage = "Error parsing %s: expected %s but received: %s";
+        final String exceptionMessage = "Error parsing %s at %s: expected %s but received: %s";
         String actualTokenValue = getToken(position).map(Token::toString).orElse("none");
+        String linePosition;
+        if (position >= sourcedTokens.size()) {
+            linePosition = "end of file";
+        } else {
+            linePosition = sourcedTokens.get(position).getSource().toPositionString();
+        }
 
-        String formattedExceptionMessage = String.format(exceptionMessage, beingParsed, expected, actualTokenValue);
+        String formattedExceptionMessage = String.format(exceptionMessage, beingParsed, linePosition, expected,
+                actualTokenValue);
         throw new ParserMalformedException(formattedExceptionMessage);
     }
 
     // Attempts to parse token array
-    public static Program parseProgram(Token[] tokens) throws ParserException {
+    public static Program parseProgram(List<Sourced<Token>> tokens) throws ParserException {
         final Parser parser = new Parser(tokens);
         final ParseResult<Program> program = parser.parseProgram(0);
         return program.result;
@@ -99,7 +108,7 @@ public class Parser {
         currentPosition = parseZeroOrMore(this::parseFunctionDef, functionDefs::add, currentPosition);
         currentPosition = parseZeroOrMore(this::parseStatement, statements::add, currentPosition);
         
-        return new ParseResult<>(new Program(structDefs, functionDefs, statements), currentPosition);
+        return getSourcedParseResult(new Program(structDefs, functionDefs, statements), position, currentPosition);
     }
 
     /**
@@ -194,11 +203,10 @@ public class Parser {
         currentPosition += 1;
 
         // Return the variable declaration
-        return Optional.of(
-            new ParseResult<>(
+        return getOptionalSourcedParseResult(
                 new StructDef(structName, params),
+                position,
                 currentPosition
-            )
         );
     }
 
@@ -225,11 +233,10 @@ public class Parser {
         currentPosition = var.nextPosition;
 
         // Return the variable declaration
-        return Optional.of(
-            new ParseResult<>(
+        return getOptionalSourcedParseResult(
                 new Param(type.result, var.result),
+                position,
                 currentPosition
-            )
         );
     }
 
@@ -247,12 +254,12 @@ public class Parser {
 
         // Throw an exception if no function name identifier
         throwParserExceptionOnUnexpected(functionDefinition, IdentifierToken.class, "a function name", currentPosition);
-        FunctionName functionName = new FunctionName(getToken(currentPosition).get().getTokenizedValue());
+        FunctionName functionName = getSourcedNode(currentPosition, (token) -> new FunctionName(token.getTokenizedValue()));
 
         currentPosition += 1;
 
         // Create the function name, update error message for this function
-        final String functionDefinitionWithName = functionDefinition + " for function " + functionName.getParsedValue();
+        final String functionDefinitionWithName = functionDefinition + " for function " + functionName.functionName;
 
         // Ensure we have a left paren (begin function params)
         throwParserExceptionOnUnexpected(functionDefinitionWithName, LeftParenToken.class, "(", currentPosition);
@@ -291,7 +298,7 @@ public class Parser {
         currentPosition = parsedStatementBlock.nextPosition;
 
         FunctionDef functionDef = new FunctionDef(functionName, functionParams, functionReturnType, functionBody);
-        return Optional.of(new ParseResult<>(functionDef, currentPosition));
+        return getOptionalSourcedParseResult(functionDef, position, currentPosition);
     }
 
     // comma_param ::= [param (`,` param)*]
@@ -348,11 +355,10 @@ public class Parser {
         throwParserExceptionOnEmptyOptional("struct actual param", optionalExp, "an expression", currentPosition);
 
         // Create struct actual param and return
-        return Optional.of(
-            new ParseResult<>(
-                new StructActualParam(optionalVar.get().result, optionalExp.get().result), 
+        return getOptionalSourcedParseResult(
+                new StructActualParam(optionalVar.get().result, optionalExp.get().result),
+                position,
                 optionalExp.get().nextPosition
-            )
         );
     }
 
@@ -360,30 +366,39 @@ public class Parser {
     public ParseResult<StructActualParams> parseStructActualParams(final int position) throws ParserException {
         final String structParamString = "struct actual params";
         int currentPosition = position;
+
         // Create a Struct Actual Param list
         List<StructActualParam> listOfActualParams = new ArrayList<>();
 
-        // Try to parse an actual param - there doesn't have to be one, I think
+        // Try to parse an actual param - there doesn't have to be one
         Optional<ParseResult<StructActualParam>> optionalStructActParam = parseStructActualParam(currentPosition);
-        if (!optionalStructActParam.isEmpty()) {
-            // If there is one, add it to the list
-            currentPosition = optionalStructActParam.get().nextPosition;
-            listOfActualParams.add(optionalStructActParam.get().result);
-            // While there's a comma next
-            while (isExpectedToken(currentPosition, CommaToken.class)) {
-                currentPosition += 1;
-                // Parse another param, add it to the param list - there has to be one now
-                optionalStructActParam = parseStructActualParam(currentPosition);
-                throwParserExceptionOnEmptyOptional(structParamString, optionalStructActParam, 
+        if (optionalStructActParam.isEmpty()) {
+            // If we have no params, then we don't need to source this result (nothing to source)
+            return new ParseResult<>(new StructActualParams(listOfActualParams), currentPosition);
+        }
+
+        // If there is one, add it to the list
+        listOfActualParams.add(optionalStructActParam.get().result);
+        currentPosition = optionalStructActParam.get().nextPosition;
+
+        // While there's a comma next
+        while (isExpectedToken(currentPosition, CommaToken.class)) {
+            currentPosition += 1;
+
+            // Parse another param, add it to the param list - there has to be one now
+            optionalStructActParam = parseStructActualParam(currentPosition);
+            throwParserExceptionOnEmptyOptional(structParamString, optionalStructActParam,
                     "struct actual param", currentPosition);
-                listOfActualParams.add(optionalStructActParam.get().result);
-                currentPosition = optionalStructActParam.get().nextPosition;
-            }
+
+            listOfActualParams.add(optionalStructActParam.get().result);
+            currentPosition = optionalStructActParam.get().nextPosition;
         }
         
         // Create struct actual params with list and return
-        return new ParseResult<StructActualParams>(
-            new StructActualParams(listOfActualParams), currentPosition
+        return getSourcedParseResult(
+                new StructActualParams(listOfActualParams),
+                position,
+                currentPosition
         );
     }
 
@@ -455,8 +470,9 @@ public class Parser {
                 continue;
             }
 
-            // Downcast the parsed statement result to just being a statement
             ParseResult<? extends Statement> realResult = optionalParseResult.get();
+
+            // Downcast the parsed statement result to just being a statement (and our statement is already sourced)
             ParseResult<Statement> statementResult = new ParseResult<>(realResult.result, realResult.nextPosition);
 
             // Return the downcasted version
@@ -496,12 +512,10 @@ public class Parser {
         currentPosition = assign.nextPosition;
 
         // Return the variable declaration
-        return Optional.of(
-            new ParseResult<>(
-                new VardecStmt(type.result, assign.result.variable, 
-                                assign.result.expression),
+        return getOptionalSourcedParseResult(
+                new VardecStmt(type.result, assign.result.variable, assign.result.expression),
+                position,
                 currentPosition
-            )
         );
     }
 
@@ -545,11 +559,10 @@ public class Parser {
         currentPosition += 1;
 
         // Return the assignment statement
-        return Optional.of(
-            new ParseResult<>(
+        return getOptionalSourcedParseResult(
                 new AssignStmt(var.result, exp.result),
+                position,
                 currentPosition
-            )
         );
     }
 
@@ -577,7 +590,7 @@ public class Parser {
 
         // [`else` stmt]: if we don't hit an else, then just return the if statement so far
         if (!isExpectedToken(currentPosition, ElseToken.class)) {
-            return Optional.of(new ParseResult<>(new IfElseStmt(condition, ifBody), currentPosition));
+            return getOptionalSourcedParseResult(new IfElseStmt(condition, ifBody), position, currentPosition);
         }
 
         currentPosition += 1;
@@ -588,7 +601,7 @@ public class Parser {
         Statement elseBody = parsedElseBody.result;
         currentPosition = parsedElseBody.nextPosition;
 
-        return Optional.of(new ParseResult<>(new IfElseStmt(condition, ifBody, elseBody), currentPosition));
+        return getOptionalSourcedParseResult(new IfElseStmt(condition, ifBody, elseBody), position, currentPosition);
     }
 
     // Parses `(` exp `)` in the context of a statement: so this is NOT a paren expression
@@ -605,6 +618,7 @@ public class Parser {
         throwParserExceptionOnUnexpected(where, RightParenToken.class, ")", currentPosition);
         currentPosition += 1;
 
+        // Expression has already been sourced by now
         return new ParseResult<>(expression, currentPosition);
     }
 
@@ -631,7 +645,7 @@ public class Parser {
         currentPosition = parsedBodyResult.nextPosition;
 
         WhileStmt whileStmt = new WhileStmt(condition, body);
-        return Optional.of(new ParseResult<>(whileStmt, currentPosition));
+        return getOptionalSourcedParseResult(whileStmt, position, currentPosition);
     }
 
     // `break` `;`
@@ -646,7 +660,7 @@ public class Parser {
         throwParserExceptionOnNoSemicolon("break statement", currentPosition);
         currentPosition += 1;
 
-        return Optional.of(new ParseResult<>(new BreakStmt(), currentPosition));
+        return getOptionalSourcedParseResult(new BreakStmt(), position, currentPosition);
     }
 
     // `println` `(` exp `)` `;`
@@ -667,7 +681,7 @@ public class Parser {
         throwParserExceptionOnNoSemicolon(printlnStatement, currentPosition);
         currentPosition += 1;
 
-        return Optional.of(new ParseResult<>(new PrintlnStmt(expression), currentPosition));
+        return getOptionalSourcedParseResult(new PrintlnStmt(expression), position, currentPosition);
     }
 
     // `return` [exp] `;`
@@ -693,7 +707,7 @@ public class Parser {
         throwParserExceptionOnNoSemicolon("return statement", currentPosition);
         currentPosition += 1;
 
-        return Optional.of(new ParseResult<>(new ReturnStmt(returnValue), currentPosition));
+        return getOptionalSourcedParseResult(new ReturnStmt(returnValue), position, currentPosition);
     }
 
     // `{` stmt* `}`
@@ -711,7 +725,7 @@ public class Parser {
         throwParserExceptionOnUnexpected("statement body", RightBraceToken.class, "}", currentPosition);
         currentPosition += 1;
 
-        return Optional.of(new ParseResult<>(new StmtBlock(blockBody), currentPosition));
+        return getOptionalSourcedParseResult(new StmtBlock(blockBody), position, currentPosition);
     }
 
     // exp `;`
@@ -739,7 +753,7 @@ public class Parser {
         throwParserExceptionOnNoSemicolon("expression statement", currentPosition);
         currentPosition += 1;
 
-        return Optional.of(new ParseResult<>(new ExpressionStmt(expression), currentPosition));
+        return getOptionalSourcedParseResult(new ExpressionStmt(expression), position, currentPosition);
     }
 
     private final static Map<Token, OperatorEnum> TOKEN_TO_OP = Map.ofEntries(
@@ -795,7 +809,7 @@ public class Parser {
 
             // Create binary op expression
             Expression binOpExp = new BinaryOpExp(returnValue.get().result, op, rightExp.get().result);
-            returnValue = Optional.of(new ParseResult<Expression>(binOpExp, rightExp.get().nextPosition));
+            returnValue = getOptionalSourcedParseResult(binOpExp, position, rightExp.get().nextPosition);
             currentPosition = returnValue.get().nextPosition;
         }
 
@@ -852,7 +866,7 @@ public class Parser {
             throwParserExceptionOnEmptyOptional("add expression", rightAddExp, "an expression", currentPosition);
             // Create binary operator, wrap in expression parse result
             BinaryOpExp binOpExp = new BinaryOpExp(returnValue.get().result, op, rightAddExp.get().result);
-            returnValue = Optional.of(new ParseResult<Expression>(binOpExp, rightAddExp.get().nextPosition));
+            returnValue = getOptionalSourcedParseResult(binOpExp, position, rightAddExp.get().nextPosition);
             currentPosition = returnValue.get().nextPosition;
         }
         return returnValue;
@@ -885,7 +899,7 @@ public class Parser {
             throwParserExceptionOnEmptyOptional("dot expression", dotExp, "an expression", currentPosition);
             // Create a not unary expression, wrap in expression optional
             UnaryOpExp unaryOpExp = new UnaryOpExp(OperatorEnum.NOT, dotExp.get().result);
-            returnValue = Optional.of(new ParseResult<Expression>(unaryOpExp, dotExp.get().nextPosition));
+            returnValue = getOptionalSourcedParseResult(unaryOpExp, position, dotExp.get().nextPosition);
         } else {
             // Return a dot expression as an expression
             returnValue = parseDotExp(currentPosition);
@@ -913,7 +927,7 @@ public class Parser {
             throwParserExceptionOnEmptyOptional(dotExpString, variable, "a variable", currentPosition);
             // Create dot operator, wrap in expression parse result
             DotExp dotExp = new DotExp(returnValue.get().result, variable.get().result);
-            returnValue = Optional.of(new ParseResult<Expression>(dotExp, variable.get().nextPosition));
+            returnValue = getOptionalSourcedParseResult(dotExp, position, variable.get().nextPosition);
             currentPosition = returnValue.get().nextPosition;
         }
         return returnValue;
@@ -954,7 +968,7 @@ public class Parser {
         // Then try to parse int, bool, var or null
         if (TOKEN_TO_PRIMARY.containsKey(tokenClass)) {
             Expression exp = TOKEN_TO_PRIMARY.get(tokenClass).apply(token);
-            return Optional.of(new ParseResult<>(exp, position + 1));
+            return getOptionalSourcedParseResult(exp, position, position + 1);
         }
 
         // Then try to parse struct allocation
@@ -1008,11 +1022,10 @@ public class Parser {
             currentPosition += 1;
 
             // Create and return struct alloc
-            return Optional.of(
-                new ParseResult<Expression>(
+            return getOptionalSourcedParseResult(
                     new StructAllocExp(structType, structActParams.result),
+                    position,
                     currentPosition
-                )
             );
         }
         // Otherwise, return empty to try something else
@@ -1040,11 +1053,10 @@ public class Parser {
             throwParserExceptionOnUnexpected(funcCallString, RightParenToken.class, "right paren )", currentPosition);
             currentPosition += 1;
             // return function call
-            return Optional.of(
-                new ParseResult<Expression>(
+            return getOptionalSourcedParseResult(
                     new FuncCallExp(optionalFuncName.get().result, commaExp.result),
+                    position,
                     currentPosition
-                )
             );
         }
         // return empty if not function call
@@ -1078,12 +1090,12 @@ public class Parser {
         }
 
         // Create struct actual params with list and return
-        return new ParseResult<CommaExp>(new CommaExp(listOfExp), currentPosition);
+        return getSourcedParseResult(new CommaExp(listOfExp), position, currentPosition);
     }
 
     // `(` exp `)`
     public Optional<ParseResult<Expression>> parseParenExp(final int position) throws ParserException {
-        String parenExpString = "primary parenthesitized expression";
+        String parenExpString = "primary parenthesized expression";
 
         if (!isExpectedToken(position, LeftParenToken.class)) {
             return Optional.empty();
@@ -1103,7 +1115,7 @@ public class Parser {
 
         // Return the Expression
         Expression parenExp = new ParenExp(optionalExpression.get().result);
-        return Optional.of(new ParseResult<Expression>(parenExp, currentPosition));
+        return getOptionalSourcedParseResult(parenExp, position, currentPosition);
     }
 
     // Try to parse a function name
@@ -1117,10 +1129,11 @@ public class Parser {
         // If this is an identifier
         if (token instanceof IdentifierToken) {
             // Create a new Optional ParseResult for a Function Name
-            return Optional.of(
-                    new ParseResult<>(
+            return getOptionalSourcedParseResult(
                             new FunctionName(token.getTokenizedValue()),
-                            position + 1));
+                            position,
+                            position + 1
+            );
         }
 
         return Optional.empty();
@@ -1137,11 +1150,10 @@ public class Parser {
         // If this is an identifier
         if (token instanceof IdentifierToken) {
             // Create a new Optional ParseResult for a Variable
-            return Optional.of(
-                new ParseResult<>(
+            return getOptionalSourcedParseResult(
                     new Variable(token.getTokenizedValue()),
+                    position,
                     position + 1
-                )
             );
         }
 
@@ -1171,7 +1183,44 @@ public class Parser {
         }
 
         Type type = TOKEN_CLASS_TO_TYPE.get(tokenClass).apply(token);
-        return Optional.of(new ParseResult<>(type, position + 1));
+        return getOptionalSourcedParseResult(type, position, position + 1);
+    }
+
+    private <T extends AbstractSyntaxTreeNode> T setSource(T t,
+                                                           int inclusiveStartPosition,
+                                                           int exclusiveEndPosition) {
+        List<Source> tokenSources = new ArrayList<>();
+        for (int i = inclusiveStartPosition; i < exclusiveEndPosition; i++) {
+            tokenSources.add(sourcedTokens.get(i).getSource());
+        }
+
+        Source combinedTokenSources = Source.fromSources(tokenSources);
+        t.setSource(combinedTokenSources);
+
+        return t;
+    }
+
+    private <T extends AbstractSyntaxTreeNode> ParseResult<T> getSourcedParseResult(T t,
+                                                                                    int inclusiveStartPosition,
+                                                                                    int exclusiveEndPosition) {
+        setSource(t, inclusiveStartPosition, exclusiveEndPosition);
+        return new ParseResult<>(t, exclusiveEndPosition);
+    }
+
+    private <T extends AbstractSyntaxTreeNode> Optional<ParseResult<T>> getOptionalSourcedParseResult(T t,
+                                                                                                      int inclusiveStartPosition,
+                                                                                                      int exclusiveEndPosition) {
+        return Optional.of(getSourcedParseResult(t, inclusiveStartPosition, exclusiveEndPosition));
+    }
+
+    private <T extends AbstractSyntaxTreeNode> T getSourcedNode(int position, Function<Token, T> parseFunction) {
+        Sourced<Token> sourcedToken = sourcedTokens.get(position);
+        Token token = sourcedToken.getValue();
+
+        T node = parseFunction.apply(token);
+        node.setSource(sourcedToken.getSource());
+
+        return node;
     }
 
 }

--- a/src/main/java/refraff/parser/Parser.java
+++ b/src/main/java/refraff/parser/Parser.java
@@ -873,7 +873,7 @@ public class Parser {
             IntLiteralToken.class, (token) -> new IntLiteralExp(Integer.parseInt(token.getTokenizedValue())),
             TrueToken.class, (token) -> new BoolLiteralExp(true),
             FalseToken.class, (token) -> new BoolLiteralExp(false),
-            IdentifierToken.class, (token) -> new VariableExp(token.getTokenizedValue()),
+            IdentifierToken.class, (token) -> new VariableExp(new Variable(token.getTokenizedValue())),
             NullToken.class, (token) -> new NullExp()
     );
 

--- a/src/main/java/refraff/parser/Parser.java
+++ b/src/main/java/refraff/parser/Parser.java
@@ -1225,9 +1225,10 @@ public class Parser {
         return new ParseResult<>(t, exclusiveEndPosition);
     }
 
-    private <T extends AbstractSyntaxTreeNode> Optional<ParseResult<T>> getOptionalSourcedParseResult(T t,
-                                                                                                      int inclusiveStartPosition,
-                                                                                                      int exclusiveEndPosition) {
+    private <T extends AbstractSyntaxTreeNode> Optional<ParseResult<T>> 
+            getOptionalSourcedParseResult(T t,
+                                          int inclusiveStartPosition,
+                                          int exclusiveEndPosition) {
         return Optional.of(getSourcedParseResult(t, inclusiveStartPosition, exclusiveEndPosition));
     }
 

--- a/src/main/java/refraff/parser/Program.java
+++ b/src/main/java/refraff/parser/Program.java
@@ -8,9 +8,8 @@ import java.util.List;
 import java.util.Objects;
 
 public class Program extends AbstractSyntaxTreeNode {
-    
-    private static final String TYPE = "program";
-    private static final String TYPE_DESCRIPTOR = "Program";
+
+    private static final String NODE_TYPE_DESCRIPTOR = "program";
 
     private final List<StructDef> structDefs;
     private final List<FunctionDef> functionDefs;
@@ -19,15 +18,11 @@ public class Program extends AbstractSyntaxTreeNode {
     public Program(final List<StructDef> structDefs,
                    final List<FunctionDef> functionDefs,
                    final List<Statement> statements) {
-        super(TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.statements = statements;
         this.functionDefs = functionDefs;
         this.structDefs = structDefs;
-    }
-
-    @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
     }
 
     public List<StructDef> getStructDefs() {
@@ -44,13 +39,16 @@ public class Program extends AbstractSyntaxTreeNode {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getStructDefs(), getFunctionDefs(), getStatements());
+        return Objects.hash(super.hashCode(), getStructDefs(), getFunctionDefs(), getStatements());
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof Program otherProgram && structDefs.equals(otherProgram.structDefs)
-                && functionDefs.equals(otherProgram.functionDefs) && statements.equals(otherProgram.statements);
+        return super.equals(other)
+                && other instanceof Program otherProgram
+                && structDefs.equals(otherProgram.structDefs)
+                && functionDefs.equals(otherProgram.functionDefs)
+                && statements.equals(otherProgram.statements);
     }
 
 }

--- a/src/main/java/refraff/parser/Variable.java
+++ b/src/main/java/refraff/parser/Variable.java
@@ -1,26 +1,24 @@
 package refraff.parser;
 
-public class Variable {
+import java.util.Objects;
+
+public class Variable extends AbstractSyntaxTreeNode {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "variable";
     
     public final String name;
 
-    public Variable(final String name) {
+    public Variable(String name) {
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.name = name;
     }
 
     @Override
     public boolean equals(final Object other) {
-        return (other instanceof Variable &&
-                name.equals(((Variable)other).name));
+        return super.equals(other)
+                && other instanceof Variable otherVariable
+                && Objects.equals(name, otherVariable.name);
     }
 
-    @Override
-    public int hashCode() {
-        return name.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return "Variable(" + name + ")";
-    }
 }

--- a/src/main/java/refraff/parser/Variable.java
+++ b/src/main/java/refraff/parser/Variable.java
@@ -8,6 +8,10 @@ public class Variable {
         this.name = name;
     }
 
+    public String getName() {
+        return name;
+    }
+
     @Override
     public boolean equals(final Object other) {
         return (other instanceof Variable &&

--- a/src/main/java/refraff/parser/expression/BinaryOpExp.java
+++ b/src/main/java/refraff/parser/expression/BinaryOpExp.java
@@ -2,14 +2,19 @@ package refraff.parser.expression;
 
 import refraff.parser.operator.*;
 
+import java.util.Objects;
+
 public class BinaryOpExp extends Expression {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "binary operator";
 
     private final Expression leftExp;
     private final OperatorEnum op;
     private final Expression rightExp;
 
     public BinaryOpExp(Expression leftExp, OperatorEnum op, Expression rightExp) {
-        super(leftExp.getParsedValue() + op.getSymbol() + rightExp.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.leftExp = leftExp;
         this.op = op;
         this.rightExp = rightExp;
@@ -26,5 +31,19 @@ public class BinaryOpExp extends Expression {
     public Expression getRightExp() {
         return rightExp;
     }
-    
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getLeftExp(), getOp(), getRightExp());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof BinaryOpExp binaryOpExp
+                && Objects.equals(getLeftExp(), binaryOpExp.getLeftExp())
+                && getOp() == binaryOpExp.getOp()
+                && Objects.equals(getRightExp(), binaryOpExp.getRightExp());
+    }
+
 }

--- a/src/main/java/refraff/parser/expression/DotExp.java
+++ b/src/main/java/refraff/parser/expression/DotExp.java
@@ -2,15 +2,23 @@ package refraff.parser.expression;
 
 import refraff.parser.Variable;
 
+import java.util.Objects;
+
 // Should this be a regular binary operator? I feel weird putting any primary
 // expression in rightVar, but I guess that's the type checker's problem?
+
+// Since dot_exp ::= primary_exp (`.` var)*, I think it's good to have it separate from other bin-ops, this is more
+// restrictive than bin ops that accept any expressions as arguments
 public class DotExp extends Expression {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "dot";
     
     private final Expression leftExp;
     private final Variable rightVar;
 
     public DotExp(Expression leftExp, Variable rightVar) {
-        super(leftExp.getParsedValue() + rightVar.name);
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.leftExp = leftExp;
         this.rightVar = rightVar;
     }
@@ -22,5 +30,18 @@ public class DotExp extends Expression {
     public Variable getRightVar() {
         return rightVar;
     }
-    
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getLeftExp(), getRightVar());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof DotExp otherDotExp
+                && Objects.equals(getLeftExp(), otherDotExp.getLeftExp())
+                && Objects.equals(getRightVar(), otherDotExp.getRightVar());
+    }
+
 }

--- a/src/main/java/refraff/parser/expression/Expression.java
+++ b/src/main/java/refraff/parser/expression/Expression.java
@@ -3,18 +3,20 @@ package refraff.parser.expression;
 import refraff.parser.AbstractSyntaxTreeNode;
 import refraff.parser.type.Type;
 
+import java.util.Objects;
+
 public abstract class Expression extends AbstractSyntaxTreeNode {
     
-    private static final String TYPE_DESCRIPTOR = "Expression";
+    private static final String NODE_TYPE_DESCRIPTOR = " expression";
 
     private Type expressionType;
 
-    public Expression(String parsedValue) {
-        this(parsedValue, null);
+    public Expression(String detailedDescriptor) {
+        this(detailedDescriptor, null);
     }
 
-    public Expression(String parsedValue, Type expressionType) {
-        super(parsedValue);
+    public Expression(String detailedDescriptor, Type expressionType) {
+        super(detailedDescriptor + NODE_TYPE_DESCRIPTOR);
 
         this.expressionType = expressionType;
     }
@@ -28,7 +30,15 @@ public abstract class Expression extends AbstractSyntaxTreeNode {
     }
 
     @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), expressionType);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof Expression otherExpression
+                && Objects.equals(getExpressionType(), otherExpression.getExpressionType());
+    }
+
 }

--- a/src/main/java/refraff/parser/expression/UnaryOpExp.java
+++ b/src/main/java/refraff/parser/expression/UnaryOpExp.java
@@ -2,13 +2,18 @@ package refraff.parser.expression;
 
 import refraff.parser.operator.OperatorEnum;
 
+import java.util.Objects;
+
 public class UnaryOpExp extends Expression {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "unary operator";
     
     private final OperatorEnum op;
     private final Expression exp;
 
     public UnaryOpExp(OperatorEnum op, Expression exp) {
-        super(op.getSymbol() + exp.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.op = op;
         this.exp = exp;
     }
@@ -20,5 +25,18 @@ public class UnaryOpExp extends Expression {
     public Expression getExp() {
         return exp;
     }
-    
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getOp(), getExp());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof UnaryOpExp otherUnaryOpExp
+                && getOp() == otherUnaryOpExp.getOp()
+                && Objects.equals(getExp(), otherUnaryOpExp.getExp());
+    }
+
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/BoolLiteralExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/BoolLiteralExp.java
@@ -3,18 +3,34 @@ package refraff.parser.expression.primaryExpression;
 
 import refraff.parser.type.BoolType;
 
+import java.util.Objects;
+
 public class BoolLiteralExp extends PrimaryExpression {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "bool literal";
 
     private final boolean value;
 
     public BoolLiteralExp(boolean value) {
-        super(String.valueOf(value), new BoolType());
+        super(NODE_TYPE_DESCRIPTOR, new BoolType());
 
         this.value = value;
     }
 
     public boolean getValue() {
         return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getValue());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof BoolLiteralExp otherBoolLiteralExp
+                && getValue() == otherBoolLiteralExp.getValue();
     }
 
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/BoolLiteralExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/BoolLiteralExp.java
@@ -1,6 +1,8 @@
 package refraff.parser.expression.primaryExpression;
 
 
+import refraff.Source;
+import refraff.parser.Node;
 import refraff.parser.type.BoolType;
 
 import java.util.Objects;
@@ -15,6 +17,12 @@ public class BoolLiteralExp extends PrimaryExpression {
         super(NODE_TYPE_DESCRIPTOR, new BoolType());
 
         this.value = value;
+    }
+
+    @Override
+    public Node setSource(Source source) throws IllegalStateException {
+        getExpressionType().setSource(source);
+        return super.setSource(source);
     }
 
     public boolean getValue() {

--- a/src/main/java/refraff/parser/expression/primaryExpression/FuncCallExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/FuncCallExp.java
@@ -3,15 +3,18 @@ package refraff.parser.expression.primaryExpression;
 import refraff.parser.function.CommaExp;
 import refraff.parser.function.FunctionName;
 
+import java.util.Objects;
+
 public class FuncCallExp extends PrimaryExpression {
         
-    private static final String FUNC_CALL_EXP = "function call expression";
+    private static final String NODE_TYPE_DESCRIPTOR = "function call";
 
     private final FunctionName funcName;
     private final CommaExp commaExp;
 
     public FuncCallExp(FunctionName funcName, CommaExp commaExp) {
-        super(FUNC_CALL_EXP);   // Should I stringify the expression or something?
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.funcName = funcName;
         this.commaExp = commaExp;
 
@@ -25,4 +28,16 @@ public class FuncCallExp extends PrimaryExpression {
         return commaExp;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getFuncName(), getCommaExp());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof FuncCallExp otherFuncCallExp
+                && Objects.equals(getFuncName(), otherFuncCallExp.getFuncName())
+                && Objects.equals(getCommaExp(), otherFuncCallExp.getCommaExp());
+    }
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/IntLiteralExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/IntLiteralExp.java
@@ -3,12 +3,16 @@ package refraff.parser.expression.primaryExpression;
 
 import refraff.parser.type.IntType;
 
+import java.util.Objects;
+
 public class IntLiteralExp extends PrimaryExpression {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "int literal";
     
     private final int intLiteral;
 
     public IntLiteralExp(int intLiteral) {
-        super(Integer.toString(intLiteral), new IntType());
+        super(NODE_TYPE_DESCRIPTOR, new IntType());
 
         this.intLiteral = intLiteral;
     }
@@ -16,4 +20,17 @@ public class IntLiteralExp extends PrimaryExpression {
     public int getIntLiteral() {
         return intLiteral;
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), intLiteral);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof IntLiteralExp otherIntLiteralExp
+                && getIntLiteral() == otherIntLiteralExp.getIntLiteral();
+    }
+
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/IntLiteralExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/IntLiteralExp.java
@@ -1,6 +1,8 @@
 package refraff.parser.expression.primaryExpression;
 
 
+import refraff.Source;
+import refraff.parser.Node;
 import refraff.parser.type.IntType;
 
 import java.util.Objects;
@@ -15,6 +17,12 @@ public class IntLiteralExp extends PrimaryExpression {
         super(NODE_TYPE_DESCRIPTOR, new IntType());
 
         this.intLiteral = intLiteral;
+    }
+
+    @Override
+    public Node setSource(Source source) throws IllegalStateException {
+        getExpressionType().setSource(source);
+        return super.setSource(source);
     }
     
     public int getIntLiteral() {

--- a/src/main/java/refraff/parser/expression/primaryExpression/NullExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/NullExp.java
@@ -1,5 +1,7 @@
 package refraff.parser.expression.primaryExpression;
 
+import refraff.Source;
+import refraff.parser.Node;
 import refraff.parser.type.StructType;
 
 public class NullExp extends PrimaryExpression {
@@ -8,6 +10,12 @@ public class NullExp extends PrimaryExpression {
 
     public NullExp() {
         super(NODE_TYPE_DESCRIPTOR, new StructType(null));
+    }
+
+    @Override
+    public Node setSource(Source source) throws IllegalStateException {
+        getExpressionType().setSource(source);
+        return super.setSource(source);
     }
 
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/NullExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/NullExp.java
@@ -4,10 +4,10 @@ import refraff.parser.type.StructType;
 
 public class NullExp extends PrimaryExpression {
 
-    private static final String NULL = "null";
+    private static final String NODE_TYPE_DESCRIPTOR = "null";
 
     public NullExp() {
-        super(NULL, new StructType(null));
+        super(NODE_TYPE_DESCRIPTOR, new StructType(null));
     }
 
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/ParenExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/ParenExp.java
@@ -2,20 +2,35 @@ package refraff.parser.expression.primaryExpression;
 
 import refraff.parser.expression.Expression;
 
+import java.util.Objects;
+
 
 public class ParenExp extends PrimaryExpression {
     
-    private static final String PAREN_EXP = "parenthesitized expression";
+    private static final String NODE_TYPE_DESCRIPTOR = "parenthesized";
 
     private final Expression exp;
 
     public ParenExp(Expression exp) {
-        super(PAREN_EXP);   // Should I stringify the expression or something?
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.exp = exp;
     }
 
     public Expression getExp() {
         return exp;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getExp());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof ParenExp otherParenExp
+                && Objects.equals(getExp(), otherParenExp.getExp());
     }
 
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/PrimaryExpression.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/PrimaryExpression.java
@@ -5,18 +5,14 @@ import refraff.parser.type.Type;
 
 public class PrimaryExpression extends Expression {
     
-    private static final String TYPE_DESCRIPTOR = "Primary Expression";
+    private static final String NODE_TYPE_DESCRIPTOR = "primary ";
 
-    public PrimaryExpression(String parsedValue) {
-        super(parsedValue);
+    public PrimaryExpression(String detailedDescriptor) {
+        this(detailedDescriptor, null);
     }
 
-    public PrimaryExpression(String parsedValue, Type expressionType) {
-        super(parsedValue, expressionType);
+    public PrimaryExpression(String detailedDescriptor, Type expressionType) {
+        super(NODE_TYPE_DESCRIPTOR + detailedDescriptor, expressionType);
     }
 
-    @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
-    }
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/PrimaryExpression.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/PrimaryExpression.java
@@ -14,5 +14,4 @@ public class PrimaryExpression extends Expression {
     public PrimaryExpression(String detailedDescriptor, Type expressionType) {
         super(NODE_TYPE_DESCRIPTOR + detailedDescriptor, expressionType);
     }
-
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/StructAllocExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/StructAllocExp.java
@@ -13,6 +13,7 @@ public class StructAllocExp extends PrimaryExpression {
 
     public StructAllocExp(StructType structType, StructActualParams params) {
         super(STRUCT_ALLOC_EXP);
+
         this.structType = structType;
         this.params = params;
     }

--- a/src/main/java/refraff/parser/expression/primaryExpression/StructAllocExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/StructAllocExp.java
@@ -3,16 +3,19 @@ package refraff.parser.expression.primaryExpression;
 import refraff.parser.type.StructType;
 import refraff.parser.struct.StructActualParams;
 
+import java.util.Objects;
+
 
 public class StructAllocExp extends PrimaryExpression {
         
-    private static final String STRUCT_ALLOC_EXP = "struct allocation expression";
+    private static final String STRUCT_ALLOC_EXP = "struct allocation";
 
     private final StructType structType;
     private final StructActualParams params;
 
     public StructAllocExp(StructType structType, StructActualParams params) {
         super(STRUCT_ALLOC_EXP);
+
         this.structType = structType;
         this.params = params;
     }
@@ -23,6 +26,19 @@ public class StructAllocExp extends PrimaryExpression {
 
     public StructActualParams getParams() {
         return params;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getStructType(), getParams());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof StructAllocExp otherStructAllocExp
+                && Objects.equals(getStructType(), otherStructAllocExp.getStructType())
+                && Objects.equals(getParams(), otherStructAllocExp.getParams());
     }
 
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/VariableExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/VariableExp.java
@@ -1,12 +1,16 @@
 package refraff.parser.expression.primaryExpression;
 
 
+import java.util.Objects;
+
 public class VariableExp extends PrimaryExpression {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "variable";
 
     private final String name; // I don't know if we need this
     
     public VariableExp(String name) {
-        super(name);
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.name = name;
     }
@@ -14,4 +18,17 @@ public class VariableExp extends PrimaryExpression {
     public String getName() {
         return name;
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getName());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof VariableExp otherVariableExp
+                && Objects.equals(getName(), otherVariableExp.getName());
+    }
+
 }

--- a/src/main/java/refraff/parser/expression/primaryExpression/VariableExp.java
+++ b/src/main/java/refraff/parser/expression/primaryExpression/VariableExp.java
@@ -1,17 +1,18 @@
 package refraff.parser.expression.primaryExpression;
 
+import refraff.parser.Variable;
 
 public class VariableExp extends PrimaryExpression {
 
-    private final String name; // I don't know if we need this
+    private final Variable var;
     
-    public VariableExp(String name) {
-        super(name);
+    public VariableExp(Variable var) {
+        super(var.name);
 
-        this.name = name;
+        this.var = var;
     }
 
-    public String getName() {
-        return name;
+    public Variable getVar() {
+        return var;
     }
 }

--- a/src/main/java/refraff/parser/function/CommaExp.java
+++ b/src/main/java/refraff/parser/function/CommaExp.java
@@ -1,24 +1,32 @@
 package refraff.parser.function;
 
 import java.util.List;
+import java.util.Objects;
 
 import refraff.parser.AbstractSyntaxTreeNode;
 import refraff.parser.expression.Expression;
 
 public class CommaExp extends AbstractSyntaxTreeNode {
-        
-    private static final String TYPE = "node";
-    private static final String TYPE_DESCRIPTOR = "comma expressions";
+    private static final String NODE_TYPE_DESCRIPTOR = "comma expressions";
 
     public final List<Expression> expressions;
 
     public CommaExp(List<Expression> expressions) {
-        super(TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.expressions = expressions;
     }
 
     @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), expressions);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof CommaExp otherCommaExp
+                && Objects.equals(expressions, otherCommaExp.expressions);
+    }
+
 }

--- a/src/main/java/refraff/parser/function/CommaExp.java
+++ b/src/main/java/refraff/parser/function/CommaExp.java
@@ -17,6 +17,10 @@ public class CommaExp extends AbstractSyntaxTreeNode {
         this.expressions = expressions;
     }
 
+    public List<Expression> getExpressions() {
+        return this.expressions;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), expressions);

--- a/src/main/java/refraff/parser/function/FunctionBody.java
+++ b/src/main/java/refraff/parser/function/FunctionBody.java
@@ -1,0 +1,18 @@
+package refraff.parser.function;
+
+import java.util.List;
+
+import refraff.parser.statement.StmtBlock;
+import refraff.parser.statement.Statement;
+
+public class FunctionBody extends StmtBlock {
+
+    public FunctionBody() {
+        super(List.of());
+    }
+
+    public FunctionBody(List<Statement> blockBody) {
+        super(blockBody);
+    }
+    
+}

--- a/src/main/java/refraff/parser/function/FunctionDef.java
+++ b/src/main/java/refraff/parser/function/FunctionDef.java
@@ -6,49 +6,60 @@ import refraff.parser.struct.Param;
 import refraff.parser.type.Type;
 
 import java.util.List;
+import java.util.Objects;
 
 public class FunctionDef extends AbstractSyntaxTreeNode {
 
-    private static final String TYPE_DESCRIPTOR = "function definition";
+    private static final String NODE_TYPE_DESCRIPTOR = "function definition";
 
     /*
      fdef ::= `func` funcname `(` comma_param `)` `:` type
          `{` stmt* `}`
      */
     private final FunctionName functionName;
-    private final Type returnType;
     private final List<Param> params;
+    private final Type returnType;
     private final StmtBlock functionBody;
 
     public FunctionDef(final FunctionName functionName, final List<Param> params,
                        final Type returnType, final StmtBlock functionBody) {
-        super(functionName.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.functionName = functionName;
-        this.returnType = returnType;
         this.params = params;
+        this.returnType = returnType;
         this.functionBody = functionBody;
-    }
-
-    @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
     }
 
     public FunctionName getFunctionName() {
         return functionName;
     }
 
-    public Type getReturnType() {
-        return returnType;
-    }
-
     public List<Param> getParams() {
         return params;
     }
 
+    public Type getReturnType() {
+        return returnType;
+    }
+
     public StmtBlock getFunctionBody() {
         return functionBody;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getFunctionName(), getParams(), getReturnType(), getFunctionBody());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof FunctionDef otherFunctionDef
+                && Objects.equals(getFunctionName(), otherFunctionDef.getFunctionName())
+                && Objects.equals(getParams(), otherFunctionDef.getParams())
+                && Objects.equals(getReturnType(), otherFunctionDef.getReturnType())
+                && Objects.equals(getFunctionBody(), otherFunctionDef.getFunctionBody());
     }
 
 }

--- a/src/main/java/refraff/parser/function/FunctionDef.java
+++ b/src/main/java/refraff/parser/function/FunctionDef.java
@@ -29,6 +29,8 @@ public class FunctionDef extends AbstractSyntaxTreeNode {
         this.params = params;
         this.returnType = returnType;
         this.functionBody = functionBody;
+
+        // Also create a function signature for the function map in the typechecker
     }
 
     public FunctionName getFunctionName() {

--- a/src/main/java/refraff/parser/function/FunctionDef.java
+++ b/src/main/java/refraff/parser/function/FunctionDef.java
@@ -33,6 +33,39 @@ public class FunctionDef extends AbstractSyntaxTreeNode {
         // Also create a function signature for the function map in the typechecker
     }
 
+    // Returns true if the types in the param lists of both function defs match
+    public boolean matchesSignatureOf(FunctionDef otherFuncDef) {
+        List<Param> otherParams = otherFuncDef.getParams();
+        // If the lists are different lengths, return false
+        if (this.params.size() != otherParams.size()) {
+            return false;
+        }
+        
+        for (int i = 0; i < this.params.size(); i++) {
+            // If the types of the parameters don't match, return false
+            if (!this.params.get(i).getClass().equals(otherParams.get(i).getClass())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // // Returns true if the other comma expression's types matches this param list's types
+    // public boolean matchesSignatureOf(CommaExp otherArgs) {
+    //     // If the lists are different lengths, return false
+    //     if (this.params.size() != otherParams.size()) {
+    //         return false;
+    //     }
+
+    //     for (int i = 0; i < this.params.size(); i++) {
+    //         // If the types of the parameters don't match, return false
+    //         if (!this.params.get(i).getClass().equals(otherParams.get(i).getClass())) {
+    //             return false;
+    //         }
+    //     }
+    //     return true;
+    // }
+
     public FunctionName getFunctionName() {
         return functionName;
     }

--- a/src/main/java/refraff/parser/function/FunctionName.java
+++ b/src/main/java/refraff/parser/function/FunctionName.java
@@ -16,6 +16,10 @@ public class FunctionName extends Type {
         this.functionName = structName;
     }
 
+    public String getName() {
+        return functionName;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), functionName);

--- a/src/main/java/refraff/parser/function/FunctionName.java
+++ b/src/main/java/refraff/parser/function/FunctionName.java
@@ -2,21 +2,30 @@ package refraff.parser.function;
 
 import refraff.parser.type.Type;
 
+import java.util.Objects;
+
 public class FunctionName extends Type {
 
-    private static final String FUNCTION_NAME = "function name";
+    private static final String NODE_TYPE_DESCRIPTOR = "function name";
 
     public final String functionName;
 
     public FunctionName(final String structName) {
-        super(FUNCTION_NAME);
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.functionName = structName;
     }
 
     @Override
-    public String getParsedValue() {
-        return this.functionName;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), functionName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof FunctionName otherFunctionName
+                && Objects.equals(functionName, otherFunctionName.functionName);
     }
 
 }

--- a/src/main/java/refraff/parser/statement/AssignStmt.java
+++ b/src/main/java/refraff/parser/statement/AssignStmt.java
@@ -3,14 +3,33 @@ package refraff.parser.statement;
 import refraff.parser.Variable;
 import refraff.parser.expression.Expression;
 
+import java.util.Objects;
+
 public class AssignStmt extends Statement {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "assignment";
 
     public final Variable variable; 
     public final Expression expression;
 
     public AssignStmt(Variable variable, Expression expression) {
-        super(variable.hashCode() + expression.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.variable = variable;
         this.expression = expression;
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), variable, expression);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof AssignStmt otherAssignStmt
+                && Objects.equals(variable, otherAssignStmt.variable)
+                && Objects.equals(expression, otherAssignStmt.expression);
+    }
+
 }

--- a/src/main/java/refraff/parser/statement/BreakStmt.java
+++ b/src/main/java/refraff/parser/statement/BreakStmt.java
@@ -2,7 +2,7 @@ package refraff.parser.statement;
 
 public class BreakStmt extends Statement {
 
-    private static final String BREAK_STATEMENT = "break;";
+    private static final String BREAK_STATEMENT = "break";
 
     public BreakStmt() {
         super(BREAK_STATEMENT);

--- a/src/main/java/refraff/parser/statement/ExpressionStmt.java
+++ b/src/main/java/refraff/parser/statement/ExpressionStmt.java
@@ -2,14 +2,16 @@ package refraff.parser.statement;
 
 import refraff.parser.expression.Expression;
 
+import java.util.Objects;
+
 public class ExpressionStmt extends Statement {
 
-    private static final String EXPRESSION_FORMAT = "%s;";
+    private static final String NODE_TYPE_DESCRIPTOR = "expression";
 
     private final Expression expression;
 
     public ExpressionStmt(Expression expression) {
-        super(expression.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.expression = expression;
     }
@@ -20,11 +22,13 @@ public class ExpressionStmt extends Statement {
 
     @Override
     public int hashCode() {
-        return expression.hashCode();
+        return Objects.hash(super.hashCode(), getExpression());
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ExpressionStmt otherExpressionStmt && expression.equals(otherExpressionStmt.expression);
+        return super.equals(other)
+                && other instanceof ExpressionStmt otherExpressionStmt
+                && Objects.equals(getExpression(), otherExpressionStmt.getExpression());
     }
 }

--- a/src/main/java/refraff/parser/statement/IfElseStmt.java
+++ b/src/main/java/refraff/parser/statement/IfElseStmt.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public class IfElseStmt extends Statement {
 
+    private static final String NODE_TYPE_DESCRIPTOR = "if else";
+
     private final Expression condition;
     private final Statement ifBody;
     private final Optional<Statement> elseBody;
@@ -16,13 +18,12 @@ public class IfElseStmt extends Statement {
     }
 
     public IfElseStmt(Expression condition, Statement ifBody, Statement elseBody) {
-        super("Unsure");
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.condition = condition;
         this.ifBody = ifBody;
         this.elseBody = Optional.ofNullable(elseBody);
     }
-
 
     public Expression getCondition() {
         return condition;
@@ -38,13 +39,16 @@ public class IfElseStmt extends Statement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(condition, ifBody, elseBody);
+        return Objects.hash(super.hashCode(), condition, ifBody, elseBody);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof IfElseStmt otherIfElse && condition.equals(otherIfElse.condition)
-                && ifBody.equals(otherIfElse.ifBody) && elseBody.equals(otherIfElse.elseBody);
+        return super.equals(other)
+                && other instanceof IfElseStmt otherIfElse
+                && Objects.equals(getCondition(), otherIfElse.getCondition())
+                && Objects.equals(getIfBody(), otherIfElse.getIfBody())
+                && Objects.equals(getElseBody(), otherIfElse.getElseBody());
     }
 
 }

--- a/src/main/java/refraff/parser/statement/PrintlnStmt.java
+++ b/src/main/java/refraff/parser/statement/PrintlnStmt.java
@@ -2,6 +2,8 @@ package refraff.parser.statement;
 
 import refraff.parser.expression.Expression;
 
+import java.util.Objects;
+
 public class PrintlnStmt extends Statement {
 
     private static final String PRINTLN_FORMAT = "println(%s)";
@@ -20,12 +22,14 @@ public class PrintlnStmt extends Statement {
 
     @Override
     public int hashCode() {
-        return expression.hashCode();
+        return Objects.hash(super.hashCode(), expression);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof PrintlnStmt otherPrintln && expression.equals(otherPrintln.expression);
+        return super.equals(other)
+                && other instanceof PrintlnStmt otherPrintln
+                && Objects.equals(getExpression(), otherPrintln.getExpression());
     }
 
 }

--- a/src/main/java/refraff/parser/statement/ReturnStmt.java
+++ b/src/main/java/refraff/parser/statement/ReturnStmt.java
@@ -2,11 +2,12 @@ package refraff.parser.statement;
 
 import refraff.parser.expression.Expression;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public class ReturnStmt extends Statement {
 
-    private static final String RETURN_FORMAT = "return %s;";
+    private static final String NODE_TYPE_DESCRIPTOR = "return";
 
     private final Optional<Expression> returnValue;
 
@@ -15,7 +16,7 @@ public class ReturnStmt extends Statement {
     }
 
     public ReturnStmt(Expression expression) {
-        super(String.format(RETURN_FORMAT, expression == null ? "" : expression.getParsedValue()));
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.returnValue = Optional.ofNullable(expression);
     }
@@ -26,12 +27,14 @@ public class ReturnStmt extends Statement {
 
     @Override
     public int hashCode() {
-        return returnValue.hashCode();
+        return Objects.hash(super.hashCode(), returnValue);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ReturnStmt otherReturn && returnValue.equals(otherReturn.returnValue);
+        return super.equals(other)
+                && other instanceof ReturnStmt otherReturn
+                && Objects.equals(getReturnValue(), otherReturn.getReturnValue());
     }
 
 }

--- a/src/main/java/refraff/parser/statement/Statement.java
+++ b/src/main/java/refraff/parser/statement/Statement.java
@@ -4,14 +4,10 @@ import refraff.parser.AbstractSyntaxTreeNode;
 
 public abstract class Statement extends AbstractSyntaxTreeNode {
     
-    private static final String TYPE_DESCRIPTOR = "Statement";
+    private static final String NODE_TYPE_DESCRIPTOR = " statement";
 
-    public Statement(String parsedValue) {
-        super(parsedValue);
+    public Statement(String statementDescriptor) {
+        super(statementDescriptor + NODE_TYPE_DESCRIPTOR);
     }
 
-    @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
-    }
 }

--- a/src/main/java/refraff/parser/statement/StmtBlock.java
+++ b/src/main/java/refraff/parser/statement/StmtBlock.java
@@ -1,8 +1,11 @@
 package refraff.parser.statement;
 
 import java.util.List;
+import java.util.Objects;
 
 public class StmtBlock extends Statement {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "block";
 
     private final List<Statement> blockBody;
 
@@ -11,7 +14,7 @@ public class StmtBlock extends Statement {
     }
 
     public StmtBlock(List<Statement> blockBody) {
-        super(String.valueOf(blockBody.hashCode()));
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.blockBody = blockBody;
     }
@@ -22,12 +25,14 @@ public class StmtBlock extends Statement {
 
     @Override
     public int hashCode() {
-        return blockBody.hashCode();
+        return Objects.hash(super.hashCode(), blockBody);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof StmtBlock otherBlock && blockBody.equals(otherBlock.getBlockBody());
+        return super.equals(other)
+                && other instanceof StmtBlock otherBlock
+                && Objects.equals(getBlockBody(), otherBlock.getBlockBody());
     }
 
 }

--- a/src/main/java/refraff/parser/statement/VardecStmt.java
+++ b/src/main/java/refraff/parser/statement/VardecStmt.java
@@ -7,6 +7,8 @@ import refraff.parser.expression.Expression;
 import java.util.Objects;
 
 public class VardecStmt extends Statement {
+
+    private static final String NODE_TYPE_DESCRIPTOR = "vardec";
     
     private final Type type;
     private final Variable variable; 
@@ -14,11 +16,8 @@ public class VardecStmt extends Statement {
 
     public VardecStmt(Type type, 
             Variable variable, Expression expression) {
-        super(
-            type.getParsedValue()
-            + variable.hashCode()
-            + expression.getParsedValue()
-        );
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.type = type;
         this.variable = variable;
         this.expression = expression;
@@ -38,12 +37,16 @@ public class VardecStmt extends Statement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, variable, expression);
+        return Objects.hash(super.hashCode(), type, variable, expression);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof VardecStmt otherVardec;
+        return super.equals(other)
+                && other instanceof VardecStmt otherVardec
+                && Objects.equals(getType(), otherVardec.getType())
+                && Objects.equals(getVariable(), otherVardec.getVariable())
+                && Objects.equals(getExpression(), otherVardec.getExpression());
     }
 
 }

--- a/src/main/java/refraff/parser/statement/WhileStmt.java
+++ b/src/main/java/refraff/parser/statement/WhileStmt.java
@@ -26,13 +26,15 @@ public class WhileStmt extends Statement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(condition, body);
+        return Objects.hash(super.hashCode(), condition, body);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof WhileStmt otherWhile && condition.equals(otherWhile.condition)
-                && body.equals(otherWhile.body);
+        return super.equals(other)
+                && other instanceof WhileStmt otherWhile
+                && Objects.equals(getCondition(), otherWhile.getCondition())
+                && Objects.equals(getBody(), otherWhile.getBody());
     }
 
 }

--- a/src/main/java/refraff/parser/struct/Param.java
+++ b/src/main/java/refraff/parser/struct/Param.java
@@ -4,22 +4,33 @@ import refraff.parser.AbstractSyntaxTreeNode;
 import refraff.parser.Variable;
 import refraff.parser.type.Type;
 
+import java.util.Objects;
+
 public class Param extends AbstractSyntaxTreeNode {
 
-    private static final String TYPE = "parameter";
-    private static final String TYPE_DESCRIPTOR = "parameter";
+    private static final String NODE_TYPE_DESCRIPTOR = "parameter";
 
     public final Type type;
     public final Variable variable;
 
     public Param(final Type type, final Variable variable) {
-        super(TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.type = type;
         this.variable = variable;
     }
 
     @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), type, variable);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof Param otherParam
+                && Objects.equals(type, otherParam.type)
+                && Objects.equals(variable, otherParam.variable);
+    }
+
 }

--- a/src/main/java/refraff/parser/struct/Param.java
+++ b/src/main/java/refraff/parser/struct/Param.java
@@ -18,6 +18,10 @@ public class Param extends AbstractSyntaxTreeNode {
         this.variable = variable;
     }
 
+    public Type getType() {
+        return type;
+    }
+
     @Override
     public String getNodeTypeDescriptor() {
         return TYPE_DESCRIPTOR;

--- a/src/main/java/refraff/parser/struct/Param.java
+++ b/src/main/java/refraff/parser/struct/Param.java
@@ -24,6 +24,10 @@ public class Param extends AbstractSyntaxTreeNode {
         return type;
     }
 
+    public Variable getVariable() {
+        return variable;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), type, variable);

--- a/src/main/java/refraff/parser/struct/StructActualParam.java
+++ b/src/main/java/refraff/parser/struct/StructActualParam.java
@@ -4,22 +4,33 @@ import refraff.parser.AbstractSyntaxTreeNode;
 import refraff.parser.expression.Expression;
 import refraff.parser.Variable;
 
+import java.util.Objects;
+
 public class StructActualParam extends AbstractSyntaxTreeNode {
-        
-    private static final String TYPE = "parameter";
-    private static final String TYPE_DESCRIPTOR = "struct actual parameter";
+
+    private static final String NODE_TYPE_DESCRIPTOR = "struct actual parameter";
 
     public final Variable var;
     public final Expression exp;
 
     public StructActualParam(Variable var, Expression exp) {
-        super(TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.var = var;
         this.exp = exp;
     }
 
     @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), var, exp);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof StructActualParam otherStructActualParam
+                && Objects.equals(var, otherStructActualParam.var)
+                && Objects.equals(exp, otherStructActualParam.exp);
+    }
+
 }

--- a/src/main/java/refraff/parser/struct/StructActualParams.java
+++ b/src/main/java/refraff/parser/struct/StructActualParams.java
@@ -1,23 +1,32 @@
 package refraff.parser.struct;
 
 import java.util.List;
+import java.util.Objects;
 
 import refraff.parser.AbstractSyntaxTreeNode;
 
 public class StructActualParams extends AbstractSyntaxTreeNode {
-    
-    private static final String TYPE = "parameters";
-    private static final String TYPE_DESCRIPTOR = "struct actual parameters";
+
+    private static final String NODE_TYPE_DESCRIPTOR = "struct actual parameters";
 
     public final List<StructActualParam> params;
 
     public StructActualParams(List<StructActualParam> params) {
-        super(TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
+
         this.params = params;
     }
 
     @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), params);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof StructActualParams otherStructActualParams
+                && Objects.equals(params, otherStructActualParams.params);
+    }
+
 }

--- a/src/main/java/refraff/parser/struct/StructDef.java
+++ b/src/main/java/refraff/parser/struct/StructDef.java
@@ -1,28 +1,23 @@
 package refraff.parser.struct;
 
 import java.util.List;
+import java.util.Objects;
 
 import refraff.parser.AbstractSyntaxTreeNode;
 
 public class StructDef extends AbstractSyntaxTreeNode {
 
-    private static final String TYPE_DESCRIPTOR = "StructDef";
+    private static final String NODE_TYPE_DESCRIPTOR = "struct definition";
 
     // structdef ::= `struct` structname `{` (param `;`)* `}`
     private final StructName structName; 
     private final List<Param> params;
 
     public StructDef(final StructName structName, final List<Param> params) {
-        // This looks pretty bad, but I'm not sure how to handle it
-        super(structName.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.structName = structName;
         this.params = params;
-    }
-
-    @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
     }
 
     public StructName getStructName() {
@@ -31,6 +26,19 @@ public class StructDef extends AbstractSyntaxTreeNode {
 
     public List<Param> getParams() {
         return params;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getStructName(), getParams());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof StructDef otherStructDef
+                && Objects.equals(getStructName(), otherStructDef.getStructName())
+                && Objects.equals(getParams(), otherStructDef.getParams());
     }
 
 }

--- a/src/main/java/refraff/parser/struct/StructDef.java
+++ b/src/main/java/refraff/parser/struct/StructDef.java
@@ -1,8 +1,12 @@
 package refraff.parser.struct;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import refraff.parser.AbstractSyntaxTreeNode;
+import refraff.parser.Variable;
+import refraff.parser.type.Type;
 
 public class StructDef extends AbstractSyntaxTreeNode {
 

--- a/src/main/java/refraff/parser/struct/StructName.java
+++ b/src/main/java/refraff/parser/struct/StructName.java
@@ -15,6 +15,10 @@ public class StructName extends AbstractSyntaxTreeNode {
         this.structName = structName;
     }
 
+    public String getName() {
+        return structName;
+    }
+
     @Override
     public String getParsedValue() {
         return this.structName;

--- a/src/main/java/refraff/parser/struct/StructName.java
+++ b/src/main/java/refraff/parser/struct/StructName.java
@@ -2,31 +2,30 @@ package refraff.parser.struct;
 
 import refraff.parser.AbstractSyntaxTreeNode;
 
+import java.util.Objects;
+
 public class StructName extends AbstractSyntaxTreeNode {
     
-    private static final String STRUCT_NAME_TYPE = "struct";
+    private static final String NODE_TYPE_DESCRIPTOR = "struct name";
 
-    // I don't really think this should be var - is a string fine? Yes!
     public final String structName;
 
     public StructName(final String structName) {
-        super(structName);
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.structName = structName;
     }
 
     @Override
-    public String getParsedValue() {
-        return this.structName;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), structName);
     }
 
     @Override
-    public String getNodeTypeDescriptor() {
-        return structName;
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof StructName otherStructName
+                && Objects.equals(structName, otherStructName.structName);
     }
 
-    // I just want my linter to be quiet
-    public String getStructNameType() {
-        return STRUCT_NAME_TYPE;
-    }
 }

--- a/src/main/java/refraff/parser/type/BoolType.java
+++ b/src/main/java/refraff/parser/type/BoolType.java
@@ -8,4 +8,13 @@ public class BoolType extends Type {
         super(BOOL_TYPE);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof BoolType;
+    }
+
+    @Override
+    public int hashCode() {
+        return BOOL_TYPE.hashCode();
+    }
 }

--- a/src/main/java/refraff/parser/type/BoolType.java
+++ b/src/main/java/refraff/parser/type/BoolType.java
@@ -13,8 +13,4 @@ public class BoolType extends Type {
         return other instanceof BoolType;
     }
 
-    @Override
-    public int hashCode() {
-        return BOOL_TYPE.hashCode();
-    }
 }

--- a/src/main/java/refraff/parser/type/BoolType.java
+++ b/src/main/java/refraff/parser/type/BoolType.java
@@ -2,10 +2,10 @@ package refraff.parser.type;
 
 public class BoolType extends Type {
 
-    private static final String BOOL_TYPE = "bool";
+    private static final String NODE_TYPE_DESCRIPTOR = "bool type";
 
     public BoolType() {
-        super(BOOL_TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
     }
 
 }

--- a/src/main/java/refraff/parser/type/BoolType.java
+++ b/src/main/java/refraff/parser/type/BoolType.java
@@ -8,9 +8,4 @@ public class BoolType extends Type {
         super(NODE_TYPE_DESCRIPTOR);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        return other instanceof BoolType;
-    }
-
 }

--- a/src/main/java/refraff/parser/type/IntType.java
+++ b/src/main/java/refraff/parser/type/IntType.java
@@ -1,10 +1,10 @@
 package refraff.parser.type;
 
 public class IntType extends Type {
-    
-    private static final String INT_TYPE = "int";
+
+    private static final String NODE_TYPE_DESCRIPTOR = "int type";
 
     public IntType() {
-        super(INT_TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
     }
 }

--- a/src/main/java/refraff/parser/type/IntType.java
+++ b/src/main/java/refraff/parser/type/IntType.java
@@ -13,8 +13,4 @@ public class IntType extends Type {
         return other instanceof IntType;
     }
 
-    @Override
-    public int hashCode() {
-        return INT_TYPE.hashCode();
-    }
 }

--- a/src/main/java/refraff/parser/type/IntType.java
+++ b/src/main/java/refraff/parser/type/IntType.java
@@ -7,4 +7,14 @@ public class IntType extends Type {
     public IntType() {
         super(INT_TYPE);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof IntType;
+    }
+
+    @Override
+    public int hashCode() {
+        return INT_TYPE.hashCode();
+    }
 }

--- a/src/main/java/refraff/parser/type/IntType.java
+++ b/src/main/java/refraff/parser/type/IntType.java
@@ -8,9 +8,4 @@ public class IntType extends Type {
         super(NODE_TYPE_DESCRIPTOR);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        return other instanceof IntType;
-    }
-
 }

--- a/src/main/java/refraff/parser/type/StructType.java
+++ b/src/main/java/refraff/parser/type/StructType.java
@@ -50,8 +50,8 @@ public class StructType extends Type {
 
         StructType otherStructType = (StructType) other;
         if (isNullStruct() && otherStructType.isNullStruct()) {
-            // If we're both null, what is our actual struct type? We have no idea
-            return false;
+            // If we're both null, this is fine?
+            return true;
         } else if (isNullStruct() == otherStructType.isNullStruct()) {
             // If we're both not null, check that our struct names match exactly
             return Objects.equals(getStructName().get(), otherStructType.getStructName().get());

--- a/src/main/java/refraff/parser/type/StructType.java
+++ b/src/main/java/refraff/parser/type/StructType.java
@@ -50,11 +50,11 @@ public class StructType extends Type {
 
         StructType otherStructType = (StructType) other;
         if (isNullStruct() && otherStructType.isNullStruct()) {
-            // If we're both null, this is fine?
+            // If we're both null, this is fine.
             return true;
         } else if (isNullStruct() == otherStructType.isNullStruct()) {
             // If we're both not null, check that our struct names match exactly
-            return Objects.equals(getStructName().get(), otherStructType.getStructName().get());
+            return Objects.equals(getStructName().get().structName, otherStructType.getStructName().get().structName);
         } else {
             // If one of us is null, then the null struct type will change its type to the type of our other struct
             return true;

--- a/src/main/java/refraff/parser/type/StructType.java
+++ b/src/main/java/refraff/parser/type/StructType.java
@@ -2,6 +2,7 @@ package refraff.parser.type;
 
 import refraff.parser.struct.StructName;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public class StructType extends Type {
@@ -38,9 +39,25 @@ public class StructType extends Type {
     public boolean equals(Object other) {
         return super.equals(other)
                 && other instanceof StructType otherStructType
-                // If I or the other are null instances, but not both of us, or if we match our raw types
-                && ((isNullStruct() ^ otherStructType.isNullStruct()) ||
-                        optionalStructName.equals(otherStructType.optionalStructName));
+                && optionalStructName.equals(otherStructType.optionalStructName);
     }
 
+    @Override
+    public boolean hasTypeEquality(Type other) {
+        if (!super.hasTypeEquality(other) || !(other instanceof StructType)) {
+            return false;
+        }
+
+        StructType otherStructType = (StructType) other;
+        if (isNullStruct() && otherStructType.isNullStruct()) {
+            // If we're both null, what is our actual struct type? We have no idea
+            return false;
+        } else if (isNullStruct() == otherStructType.isNullStruct()) {
+            // If we're both not null, check that our struct names match exactly
+            return Objects.equals(getStructName().get(), otherStructType.getStructName().get());
+        } else {
+            // If one of us is null, then the null struct type will change its type to the type of our other struct
+            return true;
+        }
+    }
 }

--- a/src/main/java/refraff/parser/type/StructType.java
+++ b/src/main/java/refraff/parser/type/StructType.java
@@ -6,10 +6,12 @@ import java.util.Optional;
 
 public class StructType extends Type {
 
+    private static final String NODE_TYPE_DESCRIPTOR = "struct type";
+
     private final Optional<StructName> optionalStructName;
 
     public StructType(StructName structName) {
-        super(structName == null ? "null instance" : structName.getParsedValue());
+        super(NODE_TYPE_DESCRIPTOR);
 
         this.optionalStructName = Optional.ofNullable(structName);
     }
@@ -34,9 +36,10 @@ public class StructType extends Type {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof StructType otherStructType &&
+        return super.equals(other)
+                && other instanceof StructType otherStructType
                 // If I or the other are null instances, but not both of us, or if we match our raw types
-                ((isNullStruct() ^ otherStructType.isNullStruct()) ||
+                && ((isNullStruct() ^ otherStructType.isNullStruct()) ||
                         optionalStructName.equals(otherStructType.optionalStructName));
     }
 

--- a/src/main/java/refraff/parser/type/Type.java
+++ b/src/main/java/refraff/parser/type/Type.java
@@ -3,20 +3,13 @@ package refraff.parser.type;
 import refraff.parser.AbstractSyntaxTreeNode;
 
 public abstract class Type extends AbstractSyntaxTreeNode {
-    
-    private static final String TYPE_DESCRIPTOR = "Type";
 
-    public Type(String parsedValue) {
-        super(parsedValue);
+    public Type(String nodeTypeDescriptor) {
+        super(nodeTypeDescriptor);
     }
 
     public boolean shouldThrowOnAssignment() {
         return true;
-    }
-
-    @Override
-    public String getNodeTypeDescriptor() {
-        return TYPE_DESCRIPTOR;
     }
 
 }

--- a/src/main/java/refraff/parser/type/Type.java
+++ b/src/main/java/refraff/parser/type/Type.java
@@ -18,5 +18,4 @@ public abstract class Type extends AbstractSyntaxTreeNode {
     public String getNodeTypeDescriptor() {
         return TYPE_DESCRIPTOR;
     }
-
 }

--- a/src/main/java/refraff/parser/type/Type.java
+++ b/src/main/java/refraff/parser/type/Type.java
@@ -12,4 +12,15 @@ public abstract class Type extends AbstractSyntaxTreeNode {
         return true;
     }
 
+    /**
+     * A method to check if the types have equality between each other. This should be used over
+     * {@link Object#equals(Object)}, since our implementation also considers the source of our node
+     * when comparing equality in the AST.
+     * @param other the other type to compare
+     * @return true if the types are equivalent, false if the types are not equivalent
+     */
+    public boolean hasTypeEquality(Type other) {
+        return this.getClass().equals(other.getClass());
+    }
+
 }

--- a/src/main/java/refraff/parser/type/VoidType.java
+++ b/src/main/java/refraff/parser/type/VoidType.java
@@ -13,8 +13,4 @@ public class VoidType extends Type {
         return other instanceof VoidType;
     }
 
-    @Override
-    public int hashCode() {
-        return VOID_TYPE.hashCode();
-    }
 }

--- a/src/main/java/refraff/parser/type/VoidType.java
+++ b/src/main/java/refraff/parser/type/VoidType.java
@@ -8,9 +8,4 @@ public class VoidType extends Type {
         super(NODE_TYPE_DESCRIPTOR);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        return other instanceof VoidType;
-    }
-
 }

--- a/src/main/java/refraff/parser/type/VoidType.java
+++ b/src/main/java/refraff/parser/type/VoidType.java
@@ -2,10 +2,10 @@ package refraff.parser.type;
 
 public class VoidType extends Type {
 
-    private static final String VOID_TYPE = "void";
+    private static final String NODE_TYPE_DESCRIPTOR = "void type";
 
     public VoidType() {
-        super(VOID_TYPE);
+        super(NODE_TYPE_DESCRIPTOR);
     }
 
 }

--- a/src/main/java/refraff/parser/type/VoidType.java
+++ b/src/main/java/refraff/parser/type/VoidType.java
@@ -8,4 +8,13 @@ public class VoidType extends Type {
         super(VOID_TYPE);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof VoidType;
+    }
+
+    @Override
+    public int hashCode() {
+        return VOID_TYPE.hashCode();
+    }
 }

--- a/src/main/java/refraff/tokenizer/AbstractToken.java
+++ b/src/main/java/refraff/tokenizer/AbstractToken.java
@@ -1,5 +1,8 @@
 package refraff.tokenizer;
 
+import refraff.Source;
+import refraff.SourcePosition;
+
 public abstract class AbstractToken implements Token {
 
     /*

--- a/src/main/java/refraff/tokenizer/Token.java
+++ b/src/main/java/refraff/tokenizer/Token.java
@@ -1,5 +1,7 @@
 package refraff.tokenizer;
 
+import refraff.Sourced;
+
 public interface Token {
 
     /**

--- a/src/main/java/refraff/typechecker/Standardized.java
+++ b/src/main/java/refraff/typechecker/Standardized.java
@@ -5,6 +5,7 @@ import refraff.SourcePosition;
 import refraff.parser.Node;
 import refraff.parser.Variable;
 import refraff.parser.struct.StructName;
+import refraff.parser.function.FunctionName;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -52,6 +53,11 @@ public class Standardized<T extends Node> {
         return new Standardized<>(variable, Variable::new);
     }
 
+    // For type environment deepcopy in typechecker
+    public static Standardized<Variable> of(Standardized<Variable> standardizedVariable) {
+        return new Standardized<Variable>(standardizedVariable.getStandardizedNode(), Variable::new);
+    }
+
     public static boolean standardizedEquals(Variable variable1, Variable variable2) {
         Standardized<Variable> standardized1 = Standardized.of(variable1);
         Standardized<Variable> standardized2 = Standardized.of(variable2);
@@ -61,6 +67,10 @@ public class Standardized<T extends Node> {
 
     public static Standardized<StructName> of(StructName structName) {
         return new Standardized<>(structName, StructName::new);
+    }
+
+    public static Standardized<FunctionName> of(FunctionName funcName) {
+        return new Standardized<>(funcName, FunctionName::new);
     }
 
 }

--- a/src/main/java/refraff/typechecker/Standardized.java
+++ b/src/main/java/refraff/typechecker/Standardized.java
@@ -53,10 +53,10 @@ public class Standardized<T extends Node> {
         return new Standardized<>(variable, Variable::new);
     }
 
-    // For type environment deepcopy in typechecker
-    public static Standardized<Variable> of(Standardized<Variable> standardizedVariable) {
-        return new Standardized<Variable>(standardizedVariable.getStandardizedNode(), Variable::new);
-    }
+    // // For type environment deepcopy in typechecker
+    // public static Standardized<Variable> of(Standardized<Variable> standardizedVariable) {
+    //     return new Standardized<Variable>(standardizedVariable.getStandardizedNode(), Variable::new);
+    // }
 
     public static boolean standardizedEquals(Variable variable1, Variable variable2) {
         Standardized<Variable> standardized1 = Standardized.of(variable1);

--- a/src/main/java/refraff/typechecker/Standardized.java
+++ b/src/main/java/refraff/typechecker/Standardized.java
@@ -1,0 +1,66 @@
+package refraff.typechecker;
+
+import refraff.Source;
+import refraff.SourcePosition;
+import refraff.parser.Node;
+import refraff.parser.Variable;
+import refraff.parser.struct.StructName;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class Standardized<T extends Node> {
+
+    private final T standardizedNode;
+
+    private Standardized(T original, Function<String, T> nodeConstructor) {
+        String originalSourceString = original.getSource().getSourceString();
+
+        this.standardizedNode = nodeConstructor.apply(originalSourceString);
+        this.standardizedNode.setSource(getStandardizedSource(originalSourceString));
+    }
+
+    private Source getStandardizedSource(String originalSourceString) {
+        return new Source(
+                originalSourceString,
+                SourcePosition.DEFAULT_SOURCE_POSITION,
+                SourcePosition.DEFAULT_SOURCE_POSITION
+        );
+    }
+
+    public T getStandardizedNode() {
+        return this.standardizedNode;
+    }
+
+    @Override
+    public int hashCode() {
+        return getStandardizedNode().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof Standardized<?> otherStandardized
+                && Objects.equals(getStandardizedNode(), otherStandardized.getStandardizedNode());
+    }
+
+    @Override
+    public String toString() {
+        return "Standardized position node: " + standardizedNode.toString();
+    }
+
+    public static Standardized<Variable> of(Variable variable) {
+        return new Standardized<>(variable, Variable::new);
+    }
+
+    public static boolean standardizedEquals(Variable variable1, Variable variable2) {
+        Standardized<Variable> standardized1 = Standardized.of(variable1);
+        Standardized<Variable> standardized2 = Standardized.of(variable2);
+
+        return standardized1.equals(standardized2);
+    }
+
+    public static Standardized<StructName> of(StructName structName) {
+        return new Standardized<>(structName, StructName::new);
+    }
+
+}

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -18,22 +18,12 @@ public class Typechecker {
 
     private final Program program;
 
-    private final Map<String, StructDef> structNameToDef;
+    private final Map<Standardized<StructName>, StructDef> structNameToDef;
 
-    private Typechecker(Program program) throws TypecheckerException {
+    private Typechecker(Program program) {
         this.program = program;
 
-        // Map all the struct definitions names to their AST definitions
-        // This throws an IllegalStateException if two structs share a name
-        // Should we catch it and throw a TypecheckerException?
-        try {
-            this.structNameToDef = program.getStructDefs().stream()
-                .collect(Collectors.toMap(
-                        structDef -> structDef.getStructName().getName(),
-                        structDef -> structDef));
-        } catch (IllegalStateException e) {
-            throw new TypecheckerException("Struct declarations share a name");
-        }
+        this.structNameToDef = new HashMap<>();
     }
 
     public static void typecheckProgram(Program program) throws TypecheckerException {
@@ -42,30 +32,29 @@ public class Typechecker {
 
     private void typecheckProgram() throws TypecheckerException {
         // Create an environment map
-        Map<String, Type> typeEnv = new HashMap<>();
+        Map<Standardized<Variable>, Type> typeEnv = new HashMap<>();
         typecheckStructDefs(typeEnv);
         typecheckStatements(typeEnv);
     }
 
     private void throwTypecheckerExceptionOnVariableExists(String beingParsed, AbstractSyntaxTreeNode parent, Variable variable,
-                                                                  Map<String, Type> typeEnv) throws TypecheckerException {
-        String variableName = variable.getName();
-        if (!typeEnv.containsKey(variableName)) {
+                                                                  Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
+        if (!typeEnv.containsKey(Standardized.of(variable))) {
             return;
         }
 
-        final String errorSuffix = "variable `" + variableName + "` is already defined in this scope";
+        final String errorSuffix = "variable `" + variable.getName() + "` is already defined in this scope";
         throwTypecheckerException(beingParsed, parent, variable, errorSuffix);
     }
 
     private Type throwTypecheckerExceptionOnVariableNotExists(String beingParsed, AbstractSyntaxTreeNode parent, Variable variable,
-                                                                     Map<String, Type> typeEnv) throws TypecheckerException {
-        String variableName = variable.getName();
-        if (typeEnv.containsKey(variableName)) {
-            return typeEnv.get(variableName);
+                                                                     Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
+        Standardized<Variable> standardizedVariable = Standardized.of(variable);
+        if (typeEnv.containsKey(standardizedVariable)) {
+            return typeEnv.get(standardizedVariable);
         }
 
-        final String errorSuffix = "variable `" + variableName + "` is not defined in this scope";
+        final String errorSuffix = "variable `" + variable.getName() + "` is not defined in this scope";
         throwTypecheckerException(beingParsed, parent, variable, errorSuffix);
 
         return null;
@@ -125,7 +114,7 @@ public class Typechecker {
 
         // Add space until we're under the child, then print the error message below the caret pointer and new line
         errorMessageBuilder.append(spacePrefix);
-        errorMessageBuilder.append("   ");
+        errorMessageBuilder.append("    ");
         errorMessageBuilder.append(errorMessage);
         errorMessageBuilder.append('\n');
 
@@ -133,7 +122,27 @@ public class Typechecker {
         throw new TypecheckerException(builtErrorMessage);
     }
 
-    private void typecheckStructDefs(Map<String, Type> typeEnv) throws TypecheckerException {
+    private void typecheckStructDefs(Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
+        final String typeErrorInStructMessageFormat = "struct definition for `%s`";
+        
+        // Add all the structs manually before trying to parse a struct's fields (allow recursion/reference other structs)
+
+        // Map all the struct definitions names to their AST definitions
+        for (StructDef structDef : program.getStructDefs()) {
+            StructName structName = structDef.getStructName();
+            Standardized<StructName> standardizedStructName = Standardized.of(structName);
+            
+            // If we don't already have a struct definition defined, add it to the map
+            if (!structNameToDef.containsKey(standardizedStructName)) {
+                structNameToDef.put(standardizedStructName, structDef);
+                continue;
+            }
+            
+            String stringStructName = structName.getName();
+            throwTypecheckerException(String.format(typeErrorInStructMessageFormat, stringStructName),
+                    structDef, structName, "struct `" + stringStructName + "` has already been defined");
+        }
+        
         for (StructDef structDef : program.getStructDefs()) {
             final String typeErrorInStructMessage = "struct definition for `" + structDef.getStructName().structName + "`";
             // Add struct def variable
@@ -185,50 +194,51 @@ public class Typechecker {
 
             // Similarly, we most likely would not want functions to put their variables on the type environment
             // until we enter the body of a function
-            Set<String> variableNames = new HashSet<>();
+            Set<Standardized<Variable>> standardizedVariables = new HashSet<>();
 
             for (Param param : structDef.getParams()) {
                 // If we add a variable, and it already exists, we have a duplicate
-                if (!variableNames.add(param.variable.getName())) {
+                if (!standardizedVariables.add(Standardized.of(param.variable))) {
                     throwTypecheckerException(typeErrorInStructMessage, structDef, param,
                             param.variable.getName() + " is already defined in this struct");
                 }
 
                 // Else, check that all variable declarations for the struct do not: have a return type of void
                 // and that any struct name does exist
-                typecheckParamNoVoidAndStructNameMustExist(structDef, typeErrorInStructMessage, param);
+                final String onVariableDeclaration = typeErrorInStructMessage + " on parameter `" +
+                        param.variable.getName() + "` declaration";
+                typecheckTypeNotVoidAndStructNameMustExist(onVariableDeclaration, structDef, param.getType());
             }
         }
     }
 
-    private void typecheckParamNoVoidAndStructNameMustExist(AbstractSyntaxTreeNode parent, String errorPrefix,
-                                                            Param param) throws TypecheckerException {
-        final String onVariableDeclaration = errorPrefix + " on parameter `" + param.variable.getName() + "` declaration";
-        Type paramType = param.type;
-
-        if (paramType instanceof VoidType) {
-            throwTypecheckerException(onVariableDeclaration, parent, paramType,
-                    "void is not permitted as a type for struct parameters");
+    private void typecheckTypeNotVoidAndStructNameMustExist(String error, AbstractSyntaxTreeNode parent,
+                                                            Type type) throws TypecheckerException {
+        // If we are a void type, throw an error
+        if (type instanceof VoidType) {
+            throwTypecheckerException(error, parent, type, "`void` is only a valid type for function return values");
         }
 
-        if (!(paramType instanceof StructType)) {
+        // If we aren't a struct type, we don't care
+        if (!(type instanceof StructType)) {
             return;
         }
 
-        StructType paramStructType = (StructType) paramType;
-        String paramStructName = paramStructType.getStructName().get().getName();
+        // If we are a struct type, make sure we have a valid struct definition
+        StructType paramStructType = (StructType) type;
+        StructName paramStructName = paramStructType.getStructName().get();
 
-        if (structNameToDef.containsKey(paramStructName)) {
+        if (structNameToDef.containsKey(Standardized.of(paramStructName))) {
             return;
         }
 
-        String errorMessage = String.format("struct type %s is not defined", paramStructName);
-        throwTypecheckerException(onVariableDeclaration, parent, paramType, errorMessage);
+        String detailedErrorMessage = String.format("struct type `%s` is not defined", paramStructName.getName());
+        throwTypecheckerException(error, parent, type, detailedErrorMessage);
     }
 
     // Map of statements to their typechecking functions
     private static final Map<Class<? extends Statement>, 
-            TypecheckingVoidFunction<Typechecker, Statement, Map<String, Type>>> STMT_TO_TYPE_FUNC = Map.of(
+            TypecheckingVoidFunction<Typechecker, Statement, Map<Standardized<Variable>, Type>>> STMT_TO_TYPE_FUNC = Map.of(
         AssignStmt.class, Typechecker::typecheckAssignStmt,
         BreakStmt.class, Typechecker::typecheckBreakStmt,
         ExpressionStmt.class, Typechecker::typecheckExpStmt,
@@ -240,7 +250,7 @@ public class Typechecker {
         WhileStmt.class, Typechecker::typecheckWhileStmt
     );
 
-    private void typecheckStatements(Map<String, Type> typeEnv) throws TypecheckerException {
+    private void typecheckStatements(Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
         
         for (Statement stmt : program.getStatements()) {          
             // Get the statements class
@@ -248,7 +258,7 @@ public class Typechecker {
 
             if (!STMT_TO_TYPE_FUNC.containsKey(stmtClass)) {
                 // Isn't a statement?
-                throw new TypecheckerException("Expected statement, got: " + stmtClass.toString());
+                throw new UnsupportedOperationException("Map did not contain mapping function for: " + stmtClass);
             }
 
             // These functions will throw exceptions if there are type errors
@@ -256,7 +266,7 @@ public class Typechecker {
         }
     }
 
-    public void typecheckAssignStmt(final Statement stmt, final Map<String, Type> typeEnv)
+    public void typecheckAssignStmt(final Statement stmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         final String beingParsed = "assignment statement";
 
@@ -272,53 +282,56 @@ public class Typechecker {
         assignStmt.expression.setExpressionType(variableType);
     }
 
-    public void typecheckBreakStmt(final Statement breakStmt, final Map<String, Type> typeEnv)
+    public void typecheckBreakStmt(final Statement breakStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckExpStmt(final Statement expStmt, final Map<String, Type> typeEnv)
+    public void typecheckExpStmt(final Statement expStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         ExpressionStmt castExpStmt = (ExpressionStmt)expStmt;
         // Get expression from the expression statement, typecheck that
         typecheckExp(castExpStmt.getExpression(), typeEnv);
     }
 
-    public void typecheckIfElseStmt(final Statement ifElseStmt, final Map<String, Type> typeEnv)
+    public void typecheckIfElseStmt(final Statement ifElseStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckPrintlnStmt(final Statement printLnStmt, final Map<String, Type> typeEnv)
+    public void typecheckPrintlnStmt(final Statement printLnStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckReturnStmt(final Statement returnStmt, final Map<String, Type> typeEnv)
+    public void typecheckReturnStmt(final Statement returnStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckStmtBlock(final Statement stmtBlock, final Map<String, Type> typeEnv)
+    public void typecheckStmtBlock(final Statement stmtBlock, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckVardecStmt(final Statement vardecStmt, final Map<String, Type> typeEnv)
+    public void typecheckVardecStmt(final Statement vardecStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         VardecStmt castVardecStmt = (VardecStmt)vardecStmt;
-        // Get type
+
+        // Get type and make sure it's not void or a struct name that does not exist
         Type type = castVardecStmt.getType();
+        typecheckTypeNotVoidAndStructNameMustExist("vardec statement", vardecStmt, type);
+
         // Compare to expression
         Type expType = typecheckExp(castVardecStmt.getExpression(), typeEnv);
 
@@ -326,16 +339,16 @@ public class Typechecker {
         throwTypecheckerExceptionOnMismatchedTypes("vardec statement", vardecStmt, expType, type, expType);
 
         // Add variable to map (throw if already exists)
-        if (typeEnv.put(castVardecStmt.getVariable().getName(), type) != null) {
-            throw new TypecheckerException("Variable " + castVardecStmt.getVariable().getName() 
-                                           + " already declared");
+        if (typeEnv.put(Standardized.of(castVardecStmt.getVariable()), type) != null) {
+            throwTypecheckerExceptionOnVariableExists("vardec statement", vardecStmt, castVardecStmt.getVariable(),
+                    typeEnv);
         }
 
         // Set the expression type to be type of the variable
         castVardecStmt.getExpression().setExpressionType(type);
     }
 
-    public void typecheckWhileStmt(final Statement whileStmt, final Map<String, Type> typeEnv)
+    public void typecheckWhileStmt(final Statement whileStmt, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
@@ -344,44 +357,47 @@ public class Typechecker {
 
     // Map of Expression classes to functions that return their types
     private static final Map<Class<? extends Expression>, 
-            TypecheckingFunction<Typechecker, Expression, Map<String, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
-        BoolLiteralExp.class, (typechecker, exp, typeEnv) -> new BoolType(),
-        FuncCallExp.class, Typechecker::typecheckFuncCallExp,
-        IntLiteralExp.class, (typechecker, exp, typeEnv) -> new IntType(),
-        NullExp.class, (typechecker, exp, typeEnv) -> new StructType(null),
-        ParenExp.class, Typechecker::typecheckParenExp,
-        StructAllocExp.class, Typechecker::typecheckStructAllocExp,
-        VariableExp.class, Typechecker::typecheckVarExp,
-        BinaryOpExp.class, Typechecker::typecheckerBinOpExp,
-        DotExp.class, Typechecker::typecheckDotExp,
-        UnaryOpExp.class, Typechecker::typecheckUnaryOpExp
+            TypecheckingFunction<Typechecker, Expression, Map<Standardized<Variable>, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
+                    // We already handle the expression types in the parser for literal values
+                    BoolLiteralExp.class, (typechecker, exp, typeEnv) -> exp.getExpressionType(),
+                    IntLiteralExp.class, (typechecker, exp, typeEnv) -> exp.getExpressionType(),
+                    NullExp.class, (typechecker, exp, typeEnv) -> exp.getExpressionType(),
+
+                    // We need to typecheck these manually
+                    FuncCallExp.class, Typechecker::typecheckFuncCallExp,
+                    ParenExp.class, Typechecker::typecheckParenExp,
+                    StructAllocExp.class, Typechecker::typecheckStructAllocExp,
+                    VariableExp.class, Typechecker::typecheckVarExp,
+                    BinaryOpExp.class, Typechecker::typecheckerBinOpExp,
+                    DotExp.class, Typechecker::typecheckDotExp,
+                    UnaryOpExp.class, Typechecker::typecheckUnaryOpExp
     );
 
-    public Type typecheckFuncCallExp(final Expression funcCallExp, final Map<String, Type> typeEnv)
+    public Type typecheckFuncCallExp(final Expression funcCallExp, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public Type typecheckParenExp(final Expression parenExp, final Map<String, Type> typeEnv)
+    public Type typecheckParenExp(final Expression parenExp, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         ParenExp castParenExp = (ParenExp)parenExp;
         // Get expression in the parentheses, typecheck that
         return typecheckExp(castParenExp.getExp(), typeEnv);
     }
 
-    public Type typecheckStructAllocExp(final Expression exp, final Map<String, Type> typeEnv)
+    public Type typecheckStructAllocExp(final Expression exp, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         final String beingParsed = "struct allocation expression";
         StructAllocExp structAllocExp = (StructAllocExp) exp;
 
         // Struct name should be a safe unwrap - the parser will have looked for an identifier after new, not a null token
         StructType structType = structAllocExp.getStructType();
-        String structName = structType.getStructName().get().getName();
+        StructName structName = structType.getStructName().get();
 
         final String structWhereWeAre = "struct " + structName;
-        StructDef structDef = structNameToDef.get(structName);
+        StructDef structDef = structNameToDef.get(Standardized.of(structName));
 
         if (structDef == null) {
             throwTypecheckerException(beingParsed, exp, structType, structWhereWeAre + " is not defined");
@@ -409,7 +425,7 @@ public class Typechecker {
             Variable definedVariable = definedParam.variable;
 
             // Check that the variable names match (in order)
-            if (!definedVariable.getName().equals(allocationParam.var.getName())) {
+            if (!Standardized.standardizedEquals(definedVariable, allocationParam.var)) {
                 throwTypecheckerException(beingParsed, exp, allocationParam, "expected allocation for variable `"
                         + definedVariable.name + "` but received allocation for variable `" + allocationParam.var.name + "`");
             }
@@ -431,7 +447,7 @@ public class Typechecker {
         return structAllocExp.getStructType();
     }
 
-    public Type typecheckVarExp(final Expression expression, final Map<String, Type> typeEnv)
+    public Type typecheckVarExp(final Expression expression, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         VariableExp variableExp = (VariableExp) expression;
 
@@ -488,7 +504,7 @@ public class Typechecker {
         return operandsAreValidType(validTypes, leftHandType) && leftHandType.hasTypeEquality(rightHandType);
     }
 
-    public Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<String, Type> typeEnv)
+    public Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         // Get the left and right hand sides
         BinaryOpExp castBinOpExp = (BinaryOpExp)binaryOpExp;
@@ -502,17 +518,25 @@ public class Typechecker {
 
         // This may be unnecessary, but check that the operand is in the map
         if (!OP_TO_OPERAND_TYPE.containsKey(op) || !OP_TO_EVAL_TYPE.containsKey(op)) {
-            throw new TypecheckerException("Expected operator, but found: " + op.toString());
+            throw new UnsupportedOperationException("Map did not find binary operator for: " + op.toString());
         }
 
         // Use the operator to decide what type the expressions should be
         List<Type> validOperandTypes = OP_TO_OPERAND_TYPE.get(op);
 
+        final String error = op.getSymbol() + " expression";
+
         // Throw exception if the operands are invalid types
+        throwTypecheckerExceptionOnMismatchedTypes(error, binaryOpExp, castBinOpExp.getRightExp(),
+                leftHandType, rightHandType);
+
         if (!operandsAreValidType(validOperandTypes, leftHandType, rightHandType)) {
-            throw new TypecheckerException("Operands are of invalid type: " + validOperandTypes.toString()
-                    + ", " + leftHandType.getNodeTypeDescriptor() + " "
-                    + rightHandType.getNodeTypeDescriptor());
+            // This should really be a more descriptive error message depending on the list of valid types
+            String errorMessage = String.format("expected one type of: {%s}", validOperandTypes.stream()
+                    .map(type -> "`" + type.getNodeTypeDescriptor() + "`")
+                    .collect(Collectors.joining(", ")));
+
+            throwTypecheckerException(error, binaryOpExp, binaryOpExp, errorMessage);
         }
 
         // Return the binary operation's evaluation type and set our type for the next expression
@@ -522,7 +546,7 @@ public class Typechecker {
         return evalType;
     }
 
-    public Type typecheckDotExp(final Expression exp, final Map<String, Type> typeEnv)
+    public Type typecheckDotExp(final Expression exp, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         final String beingParsed = "dot expression";
 
@@ -530,20 +554,20 @@ public class Typechecker {
         Type leftHandType = typecheckExp(dotExp.getLeftExp(), typeEnv);
 
         if (!(leftHandType instanceof StructType)) {
-            final String errorSuffix = "expected a reference to a struct instance but received a type of "
-                    + leftHandType.getParsedValue();
+            final String errorSuffix = "expected a struct reference but received a type of `"
+                    + leftHandType.getParsedValue() + "`";
             throwTypecheckerException(beingParsed, exp, leftHandType, errorSuffix);
         }
 
         StructType structType = (StructType) leftHandType;
         if (structType.isNullStruct()) {
-            final String errorSuffix = "expected a reference to a struct instance but received raw reference to null";
+            final String errorSuffix = "expected a struct reference but received raw `null` reference";
             throwTypecheckerException(beingParsed, exp, leftHandType, errorSuffix);
         }
 
         // By this point, if we evaluated an expression that is a type of struct, that struct should absolutely exist
-        String structName = structType.getStructName().get().getName();
-        StructDef structDef = structNameToDef.get(structName);
+        StructName structName = structType.getStructName().get();
+        StructDef structDef = structNameToDef.get(Standardized.of(structName));
 
         Variable structField = dotExp.getRightVar();
         Type structFieldType = null;
@@ -557,7 +581,7 @@ public class Typechecker {
 
         // Check that the variable we used does exist as a parameter (or field) for the struct
         if (structFieldType == null) {
-            final String errorSuffix = "struct parameter " + structField.name + " is not defined on struct " + structType;
+            final String errorSuffix = "parameter `" + structField.name + "` is not defined on struct `" + structType + "`";
             throwTypecheckerException(beingParsed, exp, structField, errorSuffix);
         }
 
@@ -565,7 +589,7 @@ public class Typechecker {
         return structFieldType;
     }
 
-    public Type typecheckUnaryOpExp(final Expression exp, final Map<String, Type> typeEnv)
+    public Type typecheckUnaryOpExp(final Expression exp, final Map<Standardized<Variable>, Type> typeEnv)
             throws TypecheckerException {
         // This is VERY similar to parsing binary ops, probably could refactor at some point
         UnaryOpExp unaryOpExp = (UnaryOpExp) exp;
@@ -577,8 +601,8 @@ public class Typechecker {
         List<Type> validTypes = OP_TO_OPERAND_TYPE.get(op);
         if (!operandsAreValidType(validTypes, expressionType)) {
             // This should really be a more descriptive error message depending on the list of valid types
-            String errorMessage = String.format("expected matching types of: {%s}", validTypes.stream()
-                            .map(Type::getNodeTypeDescriptor)
+            String errorMessage = String.format("expected one type of: {%s}", validTypes.stream()
+                            .map(type -> "`" + type.getNodeTypeDescriptor() + "`")
                             .collect(Collectors.joining(", ")));
 
             throwTypecheckerException(op.getSymbol() + " expression", exp, expressionType, errorMessage);
@@ -591,7 +615,7 @@ public class Typechecker {
     }
 
     public Type typecheckExp(final Expression exp,
-                                    final Map<String, Type> typeEnv) throws TypecheckerException {
+                                    final Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
 
         // Get the expression's class
         Class<? extends Expression> expClass = exp.getClass();
@@ -599,7 +623,7 @@ public class Typechecker {
         if (!EXP_TO_TYPE_FUNC.containsKey(expClass)) {
             // Do I throw an error here? This should be an expression and it isn't? IDK
             // Maybe an "unsupported exception" letting us know we did development bad is good here
-            throw new UnsupportedOperationException("Expected expression in map, got: " + expClass);
+            throw new UnsupportedOperationException("Map did not contain mapping function for: " + expClass);
         }
 
         Type type = EXP_TO_TYPE_FUNC.get(expClass).apply(this, exp, typeEnv);

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -1,26 +1,15 @@
 package refraff.typechecker;
 
-import refraff.parser.ParseResult;
 import refraff.parser.Program;
 import refraff.parser.Variable;
-import refraff.parser.struct.Param;
-import refraff.parser.struct.StructDef;
-import refraff.parser.struct.StructName;
+import refraff.parser.struct.*;
 import refraff.parser.type.*;
-import refraff.tokenizer.IdentifierToken;
-import refraff.tokenizer.Token;
-import refraff.tokenizer.reserved.BoolToken;
-import refraff.tokenizer.reserved.IntToken;
-import refraff.tokenizer.reserved.VoidToken;
-import refraff.tokenizer.symbol.*;
 import refraff.parser.expression.primaryExpression.*;
 import refraff.parser.operator.OperatorEnum;
 import refraff.parser.expression.*;
 import refraff.parser.statement.*;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class Typechecker {
@@ -54,19 +43,104 @@ public class Typechecker {
         typecheckStatements(typeEnv);
     }
 
+    private void throwTypecheckerException(String beingParsed, String errorSuffix) throws TypecheckerException {
+        final String errorPrefix = "Typechecker error when evaluating " + beingParsed + ": ";
+        final String errorMessage = errorPrefix + errorSuffix;
+
+        throw new TypecheckerException(errorMessage);
+    }
+
+    private void throwTypecheckerExceptionOnVariableExists(String beingParsed, Variable variable,
+                                                                  Map<Variable, Type> typeEnv) throws TypecheckerException {
+        if (!typeEnv.containsKey(variable)) {
+            return;
+        }
+
+        final String errorSuffix = "expected new variable " + variable.name + " but it is already defined in scope";
+        throwTypecheckerException(beingParsed, errorSuffix);
+    }
+
+    private Type throwTypecheckerExceptionOnVariableNotExists(String beingParsed, Variable variable,
+                                                                     Map<Variable, Type> typeEnv) throws TypecheckerException {
+        if (typeEnv.containsKey(variable)) {
+            return typeEnv.get(variable);
+        }
+
+        final String errorSuffix = "expected variable " + variable.name + " to be defined in scope but it is not";
+        throwTypecheckerException(beingParsed, errorSuffix);
+
+        return null;
+    }
+
+    private void throwTypecheckerExceptionOnMismatchedTypes(String beingParsed, Type leftHand, Type rightHand)
+            throws TypecheckerException {
+        if (leftHand.equals(rightHand)) {
+            return;
+        }
+
+        final String errorSuffix = "mismatched types LHS is a(n) " + leftHand.getParsedValue() +
+                " RHS is a(n) " + rightHand.getParsedValue();
+        throwTypecheckerException(beingParsed, errorSuffix);
+    }
+
     private void typecheckStructDefs(Map<Variable, Type> typeEnv) throws TypecheckerException {
         for (StructDef structDef : program.getStructDefs()) {
             final String typeErrorInStructMessage = "Type error in struct definition for "
                     + structDef.getStructName().structName;
             // Add struct def variable
-            if (typeEnv.put(new Variable(structDef.getStructName().getName()), 
-                    new StructType(structDef.getStructName())) != null) {
-                throw new TypecheckerException(typeErrorInStructMessage + "duplicate variables with same name exist");
-            }
+
+            // I don't think we should add these to the type environment - that would treat them as variables defined in scope
+            // at all times. Take the example (valid C) below:
+
+            /*
+             * typedef struct A {
+             *   struct A* a;
+             * } A;
+             *
+             * int main() {
+             *   A* a = NULL;
+             *   a = a->a;
+             *   return 0
+             * }
+             */
+
+            // We wouldn't be able to vardec any struct parameter name in any statement in the function, since
+            // the variable would always be in scope. But we would be able to assign a value to those variables,
+            // even though that wouldn't make sense from the program's perspective. This could be an issue if we have a
+            // struct field called `size` and wanted to use the variable name `size` anywhere else in the program.
+
+            // I think the better solution would be to have the struct fields only be in scope for dot operations.
+            // This would allow for programs equivalent to ones we could generate in our target language of C:
+
+            /*
+             * struct A {
+             *   A a;
+             * }
+             *
+             * A a = null;
+             * a = a.a;
+             */
+
+            // For struct allocations, that could get a bit weirder, but we could treat the 'actual params' in structs
+            // as labels for what we should expect to use as a parameter, instead of defined variables.
+            // Something like the following:
+
+            /*
+             * struct B {
+             *   int value;
+             * }
+             *
+             * int value = 3;
+             * new B { value: value; }; // Sets the value field of B to be whatever variable value we have in scope
+             */
+
+            // Similarly, we most likely would not want functions to put their variables on the type environment
+            // until we enter the body of a function
+            Set<Variable> variables = new HashSet<>();
 
             for (Param param : structDef.getParams()) {
                 // If we add a variable, and it already exists, we have a duplicate
-                if (typeEnv.put(param.variable, param.getType()) != null) {
+                if (!variables.add(param.variable)) {
                     throw new TypecheckerException(typeErrorInStructMessage + "duplicate variables with same name exist");
                 }
 
@@ -103,7 +177,7 @@ public class Typechecker {
 
     // Map of statements to their typechecking functions
     private static final Map<Class<? extends Statement>, 
-            TypecheckingVoidFunction<Statement, Map<Variable, Type>>> STMT_TO_TYPE_FUNC = Map.of(
+            TypecheckingVoidFunction<Typechecker, Statement, Map<Variable, Type>>> STMT_TO_TYPE_FUNC = Map.of(
         AssignStmt.class, Typechecker::typecheckAssignStmt,
         BreakStmt.class, Typechecker::typecheckBreakStmt,
         ExpressionStmt.class, Typechecker::typecheckExpStmt,
@@ -127,60 +201,69 @@ public class Typechecker {
             }
 
             // These functions will throw exceptions if there are type errors
-            STMT_TO_TYPE_FUNC.get(stmtClass).apply(stmt, typeEnv);
+            STMT_TO_TYPE_FUNC.get(stmtClass).apply(this, stmt, typeEnv);
         }
     }
 
-    public static void typecheckAssignStmt(final Statement assigStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckAssignStmt(final Statement stmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        final String beingParsed = "assignment statement";
+
+        AssignStmt assignStmt = (AssignStmt) stmt;
+        Variable variable = assignStmt.variable;
+
+        Type variableType = throwTypecheckerExceptionOnVariableNotExists(beingParsed, variable, typeEnv);
+        Type expressionType = typecheckExp(assignStmt.expression, typeEnv);
+
+        throwTypecheckerExceptionOnMismatchedTypes(beingParsed, variableType, expressionType);
+
+        // Set the expression type to be type of the variable
+        assignStmt.expression.setExpressionType(variableType);
+    }
+
+    public void typecheckBreakStmt(final Statement breakStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public static void typecheckBreakStmt(final Statement breakStmt, final Map<Variable, Type> typeEnv)
-            throws TypecheckerException {
-        throw new TypecheckerException("Not implemented yet!");
-        // Type test = new VoidType();
-        // return test;
-    }
-
-    public static void typecheckExpStmt(final Statement expStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckExpStmt(final Statement expStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         ExpressionStmt castExpStmt = (ExpressionStmt)expStmt;
         // Get expression from the expression statement, typecheck that
         typecheckExp(castExpStmt.getExpression(), typeEnv);
     }
 
-    public static void typecheckIfElseStmt(final Statement ifElseStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckIfElseStmt(final Statement ifElseStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public static void typecheckPrintlnStmt(final Statement printLnStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckPrintlnStmt(final Statement printLnStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public static void typecheckReturnStmt(final Statement returnStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckReturnStmt(final Statement returnStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public static void typecheckStmtBlock(final Statement stmtBlock, final Map<Variable, Type> typeEnv)
+    public void typecheckStmtBlock(final Statement stmtBlock, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public static void typecheckVardecStmt(final Statement vardecStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckVardecStmt(final Statement vardecStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         VardecStmt castVardecStmt = (VardecStmt)vardecStmt;
         // Get type
@@ -197,9 +280,12 @@ public class Typechecker {
             throw new TypecheckerException("Variable " + castVardecStmt.getVariable().getName() 
                                            + " already declared");
         }
+
+        // Set the expression type to be type of the variable
+        castVardecStmt.getExpression().setExpressionType(type);
     }
 
-    public static void typecheckWhileStmt(final Statement whileStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckWhileStmt(final Statement whileStmt, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
@@ -208,11 +294,11 @@ public class Typechecker {
 
     // Map of Expression classes to functions that return their types
     private static final Map<Class<? extends Expression>, 
-            TypecheckingFunction<Expression, Map<Variable, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
-        BoolLiteralExp.class, (exp, typeEnv) -> new BoolType(),
+            TypecheckingFunction<Typechecker, Expression, Map<Variable, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
+        BoolLiteralExp.class, (typechecker, exp, typeEnv) -> new BoolType(),
         FuncCallExp.class, Typechecker::typecheckFuncCallExp,
-        IntLiteralExp.class, (exp, typeEnv) -> new IntType(),
-        NullExp.class, (exp, typeEnv) -> new VoidType(),
+        IntLiteralExp.class, (typechecker, exp, typeEnv) -> new IntType(),
+        NullExp.class, (typechecker, exp, typeEnv) -> new StructType(null),
         ParenExp.class, Typechecker::typecheckParenExp,
         StructAllocExp.class, Typechecker::typecheckStructAllocExp,
         VariableExp.class, Typechecker::typecheckVarExp,
@@ -221,28 +307,78 @@ public class Typechecker {
         UnaryOpExp.class, Typechecker::typecheckUnaryOpExp
     );
 
-    public static Type typecheckFuncCallExp(final Expression funcCallExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckFuncCallExp(final Expression funcCallExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public static Type typecheckParenExp(final Expression parenExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckParenExp(final Expression parenExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         ParenExp castParenExp = (ParenExp)parenExp;
         // Get expression in the parentheses, typecheck that
         return typecheckExp(castParenExp.getExp(), typeEnv);
     }
 
-    public static Type typecheckStructAllocExp(final Expression structAllocExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckStructAllocExp(final Expression exp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
-        throw new TypecheckerException("Not implemented yet!");
-        // Type test = new VoidType();
-        // return test;
+        final String beingParsed = "struct allocation expression";
+        StructAllocExp structAllocExp = (StructAllocExp) exp;
+
+        // Struct name should be a safe unwrap - the parser will have looked for an identifier after new, not a null token
+        StructType structType = structAllocExp.getStructType();
+        StructName structName = structType.getStructName().get();
+
+        final String structWhereWeAre = "struct " + structName.structName;
+        StructDef structDef = structNameToDef.get(structName);
+
+        if (structDef == null) {
+            throwTypecheckerException(beingParsed, structWhereWeAre + " is not defined");
+        }
+
+        List<Param> structDefinedParams = structDef.getParams();
+        List<StructActualParam> structAllocParams = structAllocExp.getParams().params;
+
+        int definedParameters = structDefinedParams.size();
+        int actualParameters = structAllocParams.size();
+
+        if (definedParameters != actualParameters) {
+            final String errorSuffixFormat = "expected exactly %d allocation parameters for " + structWhereWeAre
+                    + " but received %d allocation parameters";
+            throwTypecheckerException(beingParsed, String.format(errorSuffixFormat, definedParameters, actualParameters));
+        }
+
+        for (int i = 0; i < definedParameters; i++) {
+            Param definedParam = structDefinedParams.get(i);
+            StructActualParam allocationParam = structAllocParams.get(i);
+
+            Variable definedVariable = definedParam.variable;
+
+            // Check that the variable names match (in order)
+            if (!definedVariable.equals(allocationParam.var)) {
+                throwTypecheckerException(beingParsed, "expected allocation variable " + definedVariable.name
+                        + " but received " + allocationParam.var.name);
+            }
+
+            Type definedType = definedParam.type;
+
+            Expression allocationExp = allocationParam.exp;
+            Type allocationExpType = typecheckExp(allocationExp, typeEnv);
+
+            // Check that the type defined matches the allocation expression's type
+            throwTypecheckerExceptionOnMismatchedTypes(beingParsed + " " + structWhereWeAre + " for allocation variable "
+                    + definedVariable.name, definedType, allocationExpType);
+
+            // This parameter is safe!
+        }
+
+        // All parameters are safe!
+        structAllocExp.setExpressionType(structAllocExp.getStructType());
+        return structAllocExp.getStructType();
     }
 
-    public static Type typecheckVarExp(final Expression variableExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckVarExp(final Expression variableExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         VariableExp castVarExp = (VariableExp)variableExp;
         // Use optionals instead of this
@@ -256,13 +392,16 @@ public class Typechecker {
     }
 
     // Map of Enums to the types they can operate on
-    private static final Map<OperatorEnum, List<Type>> BIN_OP_TO_OPERAND_TYPE = new HashMap<>() {{
+    private static final Map<OperatorEnum, List<Type>> OP_TO_OPERAND_TYPE = new HashMap<>() {{
+        put(OperatorEnum.NOT, List.of(new BoolType()));
         put(OperatorEnum.OR, Arrays.asList(new BoolType()));
         put(OperatorEnum.AND, Arrays.asList(new BoolType()));
         put(OperatorEnum.DOUBLE_EQUALS, Arrays.asList(new BoolType(), new IntType()));
         put(OperatorEnum.NOT_EQUALS, Arrays.asList(new BoolType(), new IntType()));
         put(OperatorEnum.LESS_THAN_EQUALS, Arrays.asList(new IntType()));
         put(OperatorEnum.GREATER_THAN_EQUALS, Arrays.asList(new IntType()));
+        put(OperatorEnum.LESS_THAN, Arrays.asList(new IntType()));
+        put(OperatorEnum.GREATER_THAN, Arrays.asList(new IntType()));
         put(OperatorEnum.PLUS, Arrays.asList(new IntType()));
         put(OperatorEnum.MINUS, Arrays.asList(new IntType()));
         put(OperatorEnum.MULTIPLY, Arrays.asList(new IntType()));
@@ -270,24 +409,32 @@ public class Typechecker {
     }};
 
     // Map of Enums to the types they evaluate to
-    private static final Map<OperatorEnum, Type> BIN_OP_TO_EVAL_TYPE = new HashMap<>() {{
+    private static final Map<OperatorEnum, Type> OP_TO_EVAL_TYPE = new HashMap<>() {{
+        put(OperatorEnum.NOT, new BoolType());
         put(OperatorEnum.OR, new BoolType());
         put(OperatorEnum.AND, new BoolType());
         put(OperatorEnum.DOUBLE_EQUALS, new BoolType());
         put(OperatorEnum.NOT_EQUALS, new BoolType());
         put(OperatorEnum.LESS_THAN_EQUALS, new BoolType());
         put(OperatorEnum.GREATER_THAN_EQUALS, new BoolType());
+        put(OperatorEnum.LESS_THAN, new BoolType());
+        put(OperatorEnum.GREATER_THAN, new BoolType());
         put(OperatorEnum.PLUS, new IntType());
         put(OperatorEnum.MINUS, new IntType());
         put(OperatorEnum.MULTIPLY, new IntType());
         put(OperatorEnum.DIVISION, new IntType());
     }};
 
-    public static boolean operandsAreValidType(List<Type> validTypes, Type leftHandType, Type rightHandType) {
+    public boolean operandsAreValidType(List<Type> validTypes, Type type) {
+        return validTypes.contains(type);
+    }
+
+    // In all cases, we need our types to match - what if LHT and RHT are both in the valid type list, but aren't the same?
+    public boolean operandsAreValidType(List<Type> validTypes, Type leftHandType, Type rightHandType) {
         return validTypes.contains(leftHandType) && validTypes.contains(rightHandType);
     }
 
-    public static Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         // Get the left and right hand sides
         BinaryOpExp castBinOpExp = (BinaryOpExp)binaryOpExp;
@@ -295,12 +442,16 @@ public class Typechecker {
         Type rightHandType = typecheckExp(castBinOpExp.getRightExp(), typeEnv);
         OperatorEnum op = castBinOpExp.getOp();
 
+        if (op == OperatorEnum.DOT) {
+            return typecheckDotExp(binaryOpExp, typeEnv);
+        }
+
         // This may be unnecessary, but check that the operand is in the map
-        if (!BIN_OP_TO_OPERAND_TYPE.containsKey(op) || !BIN_OP_TO_EVAL_TYPE.containsKey(op)) {
+        if (!OP_TO_OPERAND_TYPE.containsKey(op) || !OP_TO_EVAL_TYPE.containsKey(op)) {
             throw new TypecheckerException("Expected operator, but found: " + op.toString());
         }
         // Use the operator to decide what type the expressions should be
-        List<Type> validOperandTypes = BIN_OP_TO_OPERAND_TYPE.get(op);
+        List<Type> validOperandTypes = OP_TO_OPERAND_TYPE.get(op);
 
         // Throw exception if the operands are invalid types
         if (!operandsAreValidType(validOperandTypes, leftHandType, rightHandType)) {
@@ -309,25 +460,77 @@ public class Typechecker {
                     + rightHandType.getNodeTypeDescriptor());
         }
 
-        // Return the binary operation's evaluation type
-        return BIN_OP_TO_EVAL_TYPE.get(op);
+        // Return the binary operation's evaluation type and set our type for the next expression
+        Type evalType = OP_TO_EVAL_TYPE.get(op);
+        binaryOpExp.setExpressionType(evalType);
+
+        return evalType;
     }
 
-    public static Type typecheckDotExp(final Expression dotExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckDotExp(final Expression exp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
-        throw new TypecheckerException("Not implemented yet!");
-        // Type test = new VoidType();
-        // return test;
+        final String beingParsed = "dot expression";
+
+        DotExp dotExp = (DotExp) exp;
+        Type leftHandType = typecheckExp(dotExp.getLeftExp(), typeEnv);
+
+        if (!(leftHandType instanceof StructType)) {
+            final String errorSuffix = "expected a reference to a struct instance but received a type of "
+                    + leftHandType.getParsedValue();
+            throwTypecheckerException(beingParsed, errorSuffix);
+        }
+
+        StructType structType = (StructType) leftHandType;
+        if (structType.isNullStruct()) {
+            final String errorSuffix = "expected a reference to a struct instance but received raw reference to null";
+            throwTypecheckerException(beingParsed, errorSuffix);
+        }
+
+        // By this point, if we evaluated an expression that is a type of struct, that struct should absolutely exist
+        StructDef structDef = structNameToDef.get(structType.getStructName().get());
+
+        Variable structField = dotExp.getRightVar();
+        Type structFieldType = null;
+
+        for (Param param : structDef.getParams()) {
+            if (structField.equals(param.variable)) {
+                structFieldType = param.type;
+                break;
+            }
+        }
+
+        // Check that the variable we used does exist as a parameter (or field) for the struct
+        if (structFieldType == null) {
+            final String errorSuffix = "expected a valid struct field but received unknown field " + structField.name;
+            throwTypecheckerException(beingParsed, errorSuffix);
+        }
+
+        dotExp.setExpressionType(structFieldType);
+        return structFieldType;
     }
 
-    public static Type typecheckUnaryOpExp(final Expression unaryOpExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckUnaryOpExp(final Expression exp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
-        throw new TypecheckerException("Not implemented yet!");
-        // Type test = new VoidType();
-        // return test;
+        // This is VERY similar to parsing binary ops, probably could refactor at some point
+        UnaryOpExp unaryOpExp = (UnaryOpExp) exp;
+        OperatorEnum op = unaryOpExp.getOp();
+
+        Expression expression = unaryOpExp.getExp();
+        Type expressionType = typecheckExp(expression, typeEnv);
+
+        List<Type> validTypes = OP_TO_OPERAND_TYPE.get(op);
+        if (!operandsAreValidType(validTypes, expressionType)) {
+            // This should really be a more descriptive error message depending on the list of valid types
+            throwTypecheckerException(op.getSymbol() + " expression", "type mismatch");
+        }
+
+        Type evalType = OP_TO_EVAL_TYPE.get(op);
+        unaryOpExp.setExpressionType(evalType);
+
+        return evalType;
     }
 
-    public static Type typecheckExp(final Expression exp,
+    public Type typecheckExp(final Expression exp,
                                     final Map<Variable, Type> typeEnv) throws TypecheckerException {
 
         // Get the expression's class
@@ -338,7 +541,8 @@ public class Typechecker {
             throw new TypecheckerException("Expected expression, got: " + expClass.toString());
         }
 
-        Type type = EXP_TO_TYPE_FUNC.get(expClass).apply(exp, typeEnv);
+        Type type = EXP_TO_TYPE_FUNC.get(expClass).apply(this, exp, typeEnv);
         return type;
     }
+
 }

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -215,9 +215,8 @@ public class Typechecker {
 
     public static Type typecheckVarExp(final Expression variableExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
-        throw new TypecheckerException("Not implemented yet!");
-        // Type test = new VoidType();
-        // return test;
+        VariableExp castVarExp = (VariableExp)variableExp;
+        return typeEnv.get(castVarExp.getVar());
     }
 
     // Map of Enums to the types they can operate on

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -141,7 +141,7 @@ public class Typechecker {
             
             String stringStructName = structName.getName();
             throwTypecheckerException(String.format(typeErrorInStructMessageFormat, stringStructName),
-                    structDef, structName, "struct `" + stringStructName + "` has already been defined");
+                    structDef, structName, "struct type `" + stringStructName + "` has already been defined");
         }
         
         for (StructDef structDef : program.getStructDefs()) {
@@ -397,11 +397,11 @@ public class Typechecker {
         StructType structType = structAllocExp.getStructType();
         StructName structName = structType.getStructName().get();
 
-        final String structWhereWeAre = "struct `" + structName + "`";
+        final String structWhereWeAre = "struct type `" + structName.getSource().getSourceString() + "`";
         StructDef structDef = structNameToDef.get(Standardized.of(structName));
 
         if (structDef == null) {
-            throwTypecheckerException(beingParsed, exp, structType, structWhereWeAre + " is not defined");
+            throwTypecheckerException(beingParsed, exp, structName, structWhereWeAre + " is not defined");
         }
 
         List<Param> structDefinedParams = structDef.getParams();
@@ -586,7 +586,7 @@ public class Typechecker {
 
         // Check that the variable we used does exist as a parameter (or field) for the struct
         if (structFieldType == null) {
-            final String errorSuffix = "parameter `" + structField.name + "` is not defined on struct `" + structType + "`";
+            final String errorSuffix = "parameter `" + structField.name + "` is not defined on struct type `" + structType + "`";
             throwTypecheckerException(beingParsed, exp, structField, errorSuffix);
         }
 

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -16,12 +16,10 @@ import refraff.tokenizer.symbol.*;
 import refraff.parser.expression.primaryExpression.*;
 import refraff.parser.operator.OperatorEnum;
 import refraff.parser.expression.*;
+import refraff.parser.statement.*;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -45,13 +43,15 @@ public class Typechecker {
 
     private void typecheckProgram() throws TypecheckerException {
         typecheckStructDefs();
+        typecheckStatements();
     }
 
     private void typecheckStructDefs() throws TypecheckerException {
         for (StructDef structDef : program.getStructDefs()) {
             final String typeErrorInStructMessage = "Type error in struct definition for "
                     + structDef.getStructName().structName;
-            final Set<Variable> variables = new HashSet<>();
+            // Should this be global? We'll need to check other vardecs against it
+            final Set<Variable> variables = new HashSet<>(); 
 
             for (Param param : structDef.getParams()) {
                 // If we add a variable, and it already exists, we have a duplicate
@@ -90,9 +90,96 @@ public class Typechecker {
         throw new TypecheckerException(onVariableDeclaration + errorMessage);
     }
 
+    // Map of statements to their typechecking functions
+    private static final Map<Class<? extends Statement>, 
+            TypecheckingFunction<Statement, Map<Variable, Type>, Type>> STMT_TO_TYPE_FUNC = Map.of(
+        AssignStmt.class, Typechecker::typecheckAssignStmt,
+        ExpressionStmt.class, Typechecker::typecheckExpStmt,
+        IfElseStmt.class, Typechecker::typecheckIfElseStmt,
+        PrintlnStmt.class, Typechecker::typecheckPrintlnStmt,
+        ReturnStmt.class, Typechecker::typecheckReturnStmt,
+        StmtBlock.class, Typechecker::typecheckStmtBlock,
+        VardecStmt.class, Typechecker::typecheckVardecStmt,
+        WhileStmt.class, Typechecker::typecheckerWhileStmt
+    );
+
+    private void typecheckStatements() throws TypecheckerException {
+        // Create an environment map
+        Map<Variable, Type> typeEnv = new HashMap<>();
+
+        for (Statement stmt : program.getStatements()) {          
+            // Get the statements class
+            Class<? extends Statement> stmtClass = stmt.getClass();
+
+            if (!STMT_TO_TYPE_FUNC.containsKey(stmtClass)) {
+                // Isn't a statement?
+                throw new TypecheckerException("Expected statement, got: " + stmtClass.toString());
+            }
+
+            // These functions will throw exceptions if there are type errors
+            STMT_TO_TYPE_FUNC.get(stmtClass).apply(stmt, typeEnv);
+        }
+    }
+
+    public static Type typecheckAssignStmt(final Statement assigStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckExpStmt(final Statement expStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        ExpressionStmt castExpStmt = (ExpressionStmt)expStmt;
+        // Get expression from the expression statement, typecheck that
+        return typecheckExp(castExpStmt.getExpression(), typeEnv);
+    }
+
+    public static Type typecheckIfElseStmt(final Statement ifElseStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckPrintlnStmt(final Statement printLnStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckReturnStmt(final Statement returnStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckStmtBlock(final Statement stmtBlock, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckVardecStmt(final Statement vardecStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckerWhileStmt(final Statement whileStmt, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
     // Map of Expression classes to functions that return their types
     private static final Map<Class<? extends Expression>, 
-            TypecheckingFunction<Expression, Map<Variable, Type>, Type>> EXP_TO_TYPE = Map.of(
+            TypecheckingFunction<Expression, Map<Variable, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
         BoolLiteralExp.class, (exp, typeEnv) -> new BoolType(),
         FuncCallExp.class, Typechecker::typecheckFuncCallExp,
         IntLiteralExp.class, (exp, typeEnv) -> new IntType(),
@@ -105,43 +192,99 @@ public class Typechecker {
         UnaryOpExp.class, Typechecker::typecheckUnaryOpExp
     );
 
-    public static Type typecheckFuncCallExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+    public static Type typecheckFuncCallExp(final Expression funcCallExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckParenExp(final Expression parenExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        ParenExp castParenExp = (ParenExp)parenExp;
+        // Get expression in the parentheses, typecheck that
+        return typecheckExp(castParenExp.getExp(), typeEnv);
+    }
+
+    public static Type typecheckStructAllocExp(final Expression structAllocExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    public static Type typecheckVarExp(final Expression variableExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        throw new TypecheckerException("Not implemented yet!");
+        // Type test = new VoidType();
+        // return test;
+    }
+
+    // Map of Enums to the types they can operate on
+    private static final Map<OperatorEnum, List<Type>> BIN_OP_TO_OPERAND_TYPE = new HashMap<>() {{
+        put(OperatorEnum.OR, Arrays.asList(new BoolType()));
+        put(OperatorEnum.AND, Arrays.asList(new BoolType()));
+        put(OperatorEnum.DOUBLE_EQUALS, Arrays.asList(new BoolType(), new IntType()));
+        put(OperatorEnum.NOT_EQUALS, Arrays.asList(new BoolType(), new IntType()));
+        put(OperatorEnum.LESS_THAN_EQUALS, Arrays.asList(new IntType()));
+        put(OperatorEnum.GREATER_THAN_EQUALS, Arrays.asList(new IntType()));
+        put(OperatorEnum.PLUS, Arrays.asList(new IntType()));
+        put(OperatorEnum.MINUS, Arrays.asList(new IntType()));
+        put(OperatorEnum.MULTIPLY, Arrays.asList(new IntType()));
+        put(OperatorEnum.DIVISION, Arrays.asList(new IntType()));
+    }};
+
+    // Map of Enums to the types they evaluate to
+    private static final Map<OperatorEnum, Type> BIN_OP_TO_EVAL_TYPE = new HashMap<>() {{
+        put(OperatorEnum.OR, new BoolType());
+        put(OperatorEnum.AND, new BoolType());
+        put(OperatorEnum.DOUBLE_EQUALS, new BoolType());
+        put(OperatorEnum.NOT_EQUALS, new BoolType());
+        put(OperatorEnum.LESS_THAN_EQUALS, new BoolType());
+        put(OperatorEnum.GREATER_THAN_EQUALS, new BoolType());
+        put(OperatorEnum.PLUS, new IntType());
+        put(OperatorEnum.MINUS, new IntType());
+        put(OperatorEnum.MULTIPLY, new IntType());
+        put(OperatorEnum.DIVISION, new IntType());
+    }};
+
+    public static boolean operandsAreValidType(List<Type> validTypes, Type leftHandType, Type rightHandType) {
+        return validTypes.contains(leftHandType) && validTypes.contains(rightHandType);
+    }
+
+    public static Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        // Get the left and right hand sides
+        BinaryOpExp castBinOpExp = (BinaryOpExp)binaryOpExp;
+        Type leftHandType = typecheckExp(castBinOpExp.getLeftExp(), typeEnv);
+        Type rightHandType = typecheckExp(castBinOpExp.getRightExp(), typeEnv);
+        OperatorEnum op = castBinOpExp.getOp();
+
+        // This may be unnecessary, but check that the operand is in the map
+        if (!BIN_OP_TO_OPERAND_TYPE.containsKey(op) || !BIN_OP_TO_EVAL_TYPE.containsKey(op)) {
+            throw new TypecheckerException("Expected operator, but found: " + op.toString());
+        }
+        // Use the operator to decide what type the expressions should be
+        List<Type> validOperandTypes = BIN_OP_TO_OPERAND_TYPE.get(op);
+
+        // Throw exception if the operands are invalid types
+        if (!operandsAreValidType(validOperandTypes, leftHandType, rightHandType)) {
+            throw new TypecheckerException("Operands are of invalid type: " + validOperandTypes.toString()
+                    + ", " + leftHandType.getNodeTypeDescriptor() + " "
+                    + rightHandType.getNodeTypeDescriptor());
+        }
+
+        // Return the binary operation's evaluation type
+        return BIN_OP_TO_EVAL_TYPE.get(op);
+    }
+
+    public static Type typecheckDotExp(final Expression dotExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         Type test = new VoidType();
         return test;
     }
 
-    public static Type typecheckParenExp(final Expression binExp, final Map<Variable, Type> typeEnv)
-            throws TypecheckerException {
-        Type test = new VoidType();
-        return test;
-    }
-
-    public static Type typecheckStructAllocExp(final Expression binExp, final Map<Variable, Type> typeEnv)
-            throws TypecheckerException {
-        Type test = new VoidType();
-        return test;
-    }
-
-    public static Type typecheckVarExp(final Expression binExp, final Map<Variable, Type> typeEnv)
-            throws TypecheckerException {
-        Type test = new VoidType();
-        return test;
-    }
-
-    public static Type typecheckerBinOpExp(final Expression binExp, final Map<Variable, Type> typeEnv)
-            throws TypecheckerException {
-        Type test = new VoidType();
-        return test;
-    }
-
-    public static Type typecheckDotExp(final Expression binExp, final Map<Variable, Type> typeEnv)
-            throws TypecheckerException {
-        Type test = new VoidType();
-        return test;
-    }
-
-    public static Type typecheckUnaryOpExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+    public static Type typecheckUnaryOpExp(final Expression unaryOpExp, final Map<Variable, Type> typeEnv)
             throws TypecheckerException {
         Type test = new VoidType();
         return test;
@@ -153,54 +296,12 @@ public class Typechecker {
         // Get the expression's class
         Class<? extends Expression> expClass = exp.getClass();
 
-        if (!EXP_TO_TYPE.containsKey(expClass)) {
+        if (!EXP_TO_TYPE_FUNC.containsKey(expClass)) {
             // Do I throw an error here? This should be an expression and it isn't? IDK
             throw new TypecheckerException("Expected expression, got: " + expClass.toString());
         }
 
-        Type type = EXP_TO_TYPE.get(expClass).apply(exp, typeEnv);
+        Type type = EXP_TO_TYPE_FUNC.get(expClass).apply(exp, typeEnv);
         return type;
-    
-
-        // if (exp instanceof IntLiteralExp) {
-        //     return new IntType();
-        // } else if (exp instanceof BoolLiteralExp) {
-        //     return new BoolType();
-        // } else if (exp instanceof VariableExp) {
-        //     final Variable variable = ((VariableExp)exp).getVar();
-        //     if (typeEnv.get(variable) {
-        //         return typeEnv.get(variable);
-        //     } else {
-        //         throw new TypecheckerException("Variable not in scope: " + variable.name);
-        //     }
-        // } else if (exp instanceof BinaryOpExp) {
-        //     final BinaryOpExp asBin = (BinaryOpExp)asBin;
-        //     return typecheckBin(asBin, typeEnv);
-        // } else {
-        //     assert(false);
-        //     throw new TypecheckerException("Haven't implemented expression typechecking yet");
-        // }
     }
-
-
-
-
-
-
-    /*
-     * private final static Map<Token, OperatorEnum> TOKEN_TO_OP = Map.ofEntries(
-        new SimpleImmutableEntry<>(new OrToken(), OperatorEnum.OR),
-        new SimpleImmutableEntry<>(new AndToken(), OperatorEnum.AND),
-        new SimpleImmutableEntry<>(new DoubleEqualsToken(), OperatorEnum.DOUBLE_EQUALS),
-        new SimpleImmutableEntry<>(new NotEqualsToken(), OperatorEnum.NOT_EQUALS),
-        new SimpleImmutableEntry<>(new LessThanEqualsToken(), OperatorEnum.LESS_THAN_EQUALS),
-        new SimpleImmutableEntry<>(new GreaterThanEqualsToken(), OperatorEnum.GREATER_THAN_EQUALS),
-        new SimpleImmutableEntry<>(new PlusToken(), OperatorEnum.PLUS),
-        new SimpleImmutableEntry<>(new MinusToken(), OperatorEnum.MINUS),
-        new SimpleImmutableEntry<>(new MultiplyToken(), OperatorEnum.MULTIPLY),
-        new SimpleImmutableEntry<>(new DivisionToken(), OperatorEnum.DIVISION),
-        new SimpleImmutableEntry<>(new NotToken(), OperatorEnum.NOT),
-        new SimpleImmutableEntry<>(new DotToken(), OperatorEnum.DOT)
-    );
-     */
 }

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -1,5 +1,7 @@
 package refraff.typechecker;
 
+import refraff.SourcePosition;
+import refraff.parser.AbstractSyntaxTreeNode;
 import refraff.parser.Program;
 import refraff.parser.Variable;
 import refraff.parser.struct.*;
@@ -16,7 +18,7 @@ public class Typechecker {
 
     private final Program program;
 
-    private final Map<StructName, StructDef> structNameToDef;
+    private final Map<String, StructDef> structNameToDef;
 
     private Typechecker(Program program) throws TypecheckerException {
         this.program = program;
@@ -26,7 +28,9 @@ public class Typechecker {
         // Should we catch it and throw a TypecheckerException?
         try {
             this.structNameToDef = program.getStructDefs().stream()
-                .collect(Collectors.toMap(StructDef::getStructName, structDef -> structDef));
+                .collect(Collectors.toMap(
+                        structDef -> structDef.getStructName().getName(),
+                        structDef -> structDef));
         } catch (IllegalStateException e) {
             throw new TypecheckerException("Struct declarations share a name");
         }
@@ -38,55 +42,100 @@ public class Typechecker {
 
     private void typecheckProgram() throws TypecheckerException {
         // Create an environment map
-        Map<Variable, Type> typeEnv = new HashMap<>();
+        Map<String, Type> typeEnv = new HashMap<>();
         typecheckStructDefs(typeEnv);
         typecheckStatements(typeEnv);
     }
 
-    private void throwTypecheckerException(String beingParsed, String errorSuffix) throws TypecheckerException {
-        final String errorPrefix = "Typechecker error when evaluating " + beingParsed + ": ";
-        final String errorMessage = errorPrefix + errorSuffix;
-
-        throw new TypecheckerException(errorMessage);
-    }
-
-    private void throwTypecheckerExceptionOnVariableExists(String beingParsed, Variable variable,
-                                                                  Map<Variable, Type> typeEnv) throws TypecheckerException {
-        if (!typeEnv.containsKey(variable)) {
+    private void throwTypecheckerExceptionOnVariableExists(String beingParsed, AbstractSyntaxTreeNode parent, Variable variable,
+                                                                  Map<String, Type> typeEnv) throws TypecheckerException {
+        String variableName = variable.getName();
+        if (!typeEnv.containsKey(variableName)) {
             return;
         }
 
-        final String errorSuffix = "expected new variable " + variable.name + " but it is already defined in scope";
-        throwTypecheckerException(beingParsed, errorSuffix);
+        final String errorSuffix = "variable `" + variableName + "` is already defined in this scope";
+        throwTypecheckerException(beingParsed, parent, variable, errorSuffix);
     }
 
-    private Type throwTypecheckerExceptionOnVariableNotExists(String beingParsed, Variable variable,
-                                                                     Map<Variable, Type> typeEnv) throws TypecheckerException {
-        if (typeEnv.containsKey(variable)) {
-            return typeEnv.get(variable);
+    private Type throwTypecheckerExceptionOnVariableNotExists(String beingParsed, AbstractSyntaxTreeNode parent, Variable variable,
+                                                                     Map<String, Type> typeEnv) throws TypecheckerException {
+        String variableName = variable.getName();
+        if (typeEnv.containsKey(variableName)) {
+            return typeEnv.get(variableName);
         }
 
-        final String errorSuffix = "expected variable " + variable.name + " to be defined in scope but it is not";
-        throwTypecheckerException(beingParsed, errorSuffix);
+        final String errorSuffix = "variable `" + variableName + "` is not defined in this scope";
+        throwTypecheckerException(beingParsed, parent, variable, errorSuffix);
 
         return null;
     }
 
-    private void throwTypecheckerExceptionOnMismatchedTypes(String beingParsed, Type leftHand, Type rightHand)
+    private void throwTypecheckerExceptionOnMismatchedTypes(String beingParsed, AbstractSyntaxTreeNode parent,
+                                                            AbstractSyntaxTreeNode rightHandChild,
+                                                            Type leftHand, Type rightHand)
             throws TypecheckerException {
-        if (leftHand.equals(rightHand)) {
+        if (leftHand.hasTypeEquality(rightHand)) {
             return;
         }
 
-        final String errorSuffix = "mismatched types LHS is a(n) " + leftHand.getParsedValue() +
-                " RHS is a(n) " + rightHand.getParsedValue();
-        throwTypecheckerException(beingParsed, errorSuffix);
+        final String errorSuffix = rightHandChild.getNodeTypeDescriptor() + " does not match expected type " +
+                leftHand.getSource().getSourceString();
+        throwTypecheckerException(beingParsed, parent, rightHandChild, errorSuffix);
     }
 
-    private void typecheckStructDefs(Map<Variable, Type> typeEnv) throws TypecheckerException {
+    private void throwTypecheckerException(String beingParsed, AbstractSyntaxTreeNode parent,
+                                           AbstractSyntaxTreeNode child, String errorMessage) throws TypecheckerException {
+        SourcePosition childStartPosition = child.getSource().getStartPosition();
+
+        StringBuilder errorMessageBuilder = new StringBuilder();
+
+        errorMessageBuilder.append("Typechecker error when evaluating ");
+        errorMessageBuilder.append(beingParsed);
+        errorMessageBuilder.append(" at ");
+        errorMessageBuilder.append(childStartPosition.toString());
+        errorMessageBuilder.append(":\n");
+
+        String parentNodeString = parent.getSource().getSourceString();
+
+        SourcePosition parentStartPosition = parent.getSource().getStartPosition();
+        SourcePosition childEndPosition = child.getSource().getEndPosition();
+
+        int numberOfLinesToPrint = (childEndPosition.getLinePosition() - parentStartPosition.getLinePosition()) + 1;
+
+        // Append all the lines until the child is fully displayed
+        parentNodeString.lines()
+                .limit(numberOfLinesToPrint)
+                .forEach(line -> {
+                    errorMessageBuilder.append(line);
+                    errorMessageBuilder.append('\n');
+                });
+
+        int numberOfSpacesToPrint = numberOfLinesToPrint == 1
+                ? childStartPosition.getColumnPosition() - parentStartPosition.getColumnPosition()
+                : childStartPosition.getColumnPosition() - 1;
+
+        String spacePrefix = " ".repeat(numberOfSpacesToPrint);
+        String caretPointer = "^".repeat(childEndPosition.getColumnPosition() - childStartPosition.getColumnPosition());
+
+        // Add spaces until we're under the child, then use the caret pointer to point to the child and new line
+        errorMessageBuilder.append(spacePrefix);
+        errorMessageBuilder.append(caretPointer);
+        errorMessageBuilder.append('\n');
+
+        // Add space until we're under the child, then print the error message below the caret pointer and new line
+        errorMessageBuilder.append(spacePrefix);
+        errorMessageBuilder.append("   ");
+        errorMessageBuilder.append(errorMessage);
+        errorMessageBuilder.append('\n');
+
+        String builtErrorMessage = errorMessageBuilder.toString();
+        throw new TypecheckerException(builtErrorMessage);
+    }
+
+    private void typecheckStructDefs(Map<String, Type> typeEnv) throws TypecheckerException {
         for (StructDef structDef : program.getStructDefs()) {
-            final String typeErrorInStructMessage = "Type error in struct definition for "
-                    + structDef.getStructName().structName;
+            final String typeErrorInStructMessage = "struct definition for `" + structDef.getStructName().structName + "`";
             // Add struct def variable
 
             // I don't think we should add these to the type environment - that would treat them as variables defined in scope
@@ -136,28 +185,30 @@ public class Typechecker {
 
             // Similarly, we most likely would not want functions to put their variables on the type environment
             // until we enter the body of a function
-            Set<Variable> variables = new HashSet<>();
+            Set<String> variableNames = new HashSet<>();
 
             for (Param param : structDef.getParams()) {
                 // If we add a variable, and it already exists, we have a duplicate
-                if (!variables.add(param.variable)) {
-                    throw new TypecheckerException(typeErrorInStructMessage + "duplicate variables with same name exist");
+                if (!variableNames.add(param.variable.getName())) {
+                    throwTypecheckerException(typeErrorInStructMessage, structDef, param,
+                            param.variable.getName() + " is already defined in this struct");
                 }
 
                 // Else, check that all variable declarations for the struct do not: have a return type of void
                 // and that any struct name does exist
-                typecheckParamNoVoidAndStructNameMustExist(typeErrorInStructMessage, param);
+                typecheckParamNoVoidAndStructNameMustExist(structDef, typeErrorInStructMessage, param);
             }
         }
     }
 
-    private void typecheckParamNoVoidAndStructNameMustExist(String prefix, Param param) throws TypecheckerException {
-        final String onVariableDeclaration = String.format(prefix + ", on variable declaration for %s: ",
-                param.variable.name);
+    private void typecheckParamNoVoidAndStructNameMustExist(AbstractSyntaxTreeNode parent, String errorPrefix,
+                                                            Param param) throws TypecheckerException {
+        final String onVariableDeclaration = errorPrefix + " on parameter `" + param.variable.getName() + "` declaration";
         Type paramType = param.type;
 
         if (paramType instanceof VoidType) {
-            throw new TypecheckerException(onVariableDeclaration + "void is not a valid variable type");
+            throwTypecheckerException(onVariableDeclaration, parent, paramType,
+                    "void is not permitted as a type for struct parameters");
         }
 
         if (!(paramType instanceof StructType)) {
@@ -165,19 +216,19 @@ public class Typechecker {
         }
 
         StructType paramStructType = (StructType) paramType;
-        StructName paramStructName = paramStructType.getStructName().get();
+        String paramStructName = paramStructType.getStructName().get().getName();
 
         if (structNameToDef.containsKey(paramStructName)) {
             return;
         }
 
-        String errorMessage = String.format("struct type %s is not defined", paramStructName.structName);
-        throw new TypecheckerException(onVariableDeclaration + errorMessage);
+        String errorMessage = String.format("struct type %s is not defined", paramStructName);
+        throwTypecheckerException(onVariableDeclaration, parent, paramType, errorMessage);
     }
 
     // Map of statements to their typechecking functions
     private static final Map<Class<? extends Statement>, 
-            TypecheckingVoidFunction<Typechecker, Statement, Map<Variable, Type>>> STMT_TO_TYPE_FUNC = Map.of(
+            TypecheckingVoidFunction<Typechecker, Statement, Map<String, Type>>> STMT_TO_TYPE_FUNC = Map.of(
         AssignStmt.class, Typechecker::typecheckAssignStmt,
         BreakStmt.class, Typechecker::typecheckBreakStmt,
         ExpressionStmt.class, Typechecker::typecheckExpStmt,
@@ -189,7 +240,7 @@ public class Typechecker {
         WhileStmt.class, Typechecker::typecheckWhileStmt
     );
 
-    private void typecheckStatements(Map<Variable, Type> typeEnv) throws TypecheckerException {
+    private void typecheckStatements(Map<String, Type> typeEnv) throws TypecheckerException {
         
         for (Statement stmt : program.getStatements()) {          
             // Get the statements class
@@ -205,78 +256,77 @@ public class Typechecker {
         }
     }
 
-    public void typecheckAssignStmt(final Statement stmt, final Map<Variable, Type> typeEnv)
+    public void typecheckAssignStmt(final Statement stmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         final String beingParsed = "assignment statement";
 
         AssignStmt assignStmt = (AssignStmt) stmt;
         Variable variable = assignStmt.variable;
 
-        Type variableType = throwTypecheckerExceptionOnVariableNotExists(beingParsed, variable, typeEnv);
+        Type variableType = throwTypecheckerExceptionOnVariableNotExists(beingParsed, stmt, variable, typeEnv);
         Type expressionType = typecheckExp(assignStmt.expression, typeEnv);
 
-        throwTypecheckerExceptionOnMismatchedTypes(beingParsed, variableType, expressionType);
+        throwTypecheckerExceptionOnMismatchedTypes(beingParsed, stmt, expressionType, variableType, expressionType);
 
         // Set the expression type to be type of the variable
         assignStmt.expression.setExpressionType(variableType);
     }
 
-    public void typecheckBreakStmt(final Statement breakStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckBreakStmt(final Statement breakStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckExpStmt(final Statement expStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckExpStmt(final Statement expStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         ExpressionStmt castExpStmt = (ExpressionStmt)expStmt;
         // Get expression from the expression statement, typecheck that
         typecheckExp(castExpStmt.getExpression(), typeEnv);
     }
 
-    public void typecheckIfElseStmt(final Statement ifElseStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckIfElseStmt(final Statement ifElseStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckPrintlnStmt(final Statement printLnStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckPrintlnStmt(final Statement printLnStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckReturnStmt(final Statement returnStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckReturnStmt(final Statement returnStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckStmtBlock(final Statement stmtBlock, final Map<Variable, Type> typeEnv)
+    public void typecheckStmtBlock(final Statement stmtBlock, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public void typecheckVardecStmt(final Statement vardecStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckVardecStmt(final Statement vardecStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         VardecStmt castVardecStmt = (VardecStmt)vardecStmt;
         // Get type
         Type type = castVardecStmt.getType();
         // Compare to expression
         Type expType = typecheckExp(castVardecStmt.getExpression(), typeEnv);
-        // If these are the same type
-        if (!type.equals(expType)) {
-            throw new TypecheckerException("Vardec declared type is " + type.getParsedValue()
-                                           + " but expression is " + expType.getParsedValue());
-        }
+
+        // Throw if these aren't the same type
+        throwTypecheckerExceptionOnMismatchedTypes("vardec statement", vardecStmt, expType, type, expType);
+
         // Add variable to map (throw if already exists)
-        if (typeEnv.put(castVardecStmt.getVariable(), type) != null) {
+        if (typeEnv.put(castVardecStmt.getVariable().getName(), type) != null) {
             throw new TypecheckerException("Variable " + castVardecStmt.getVariable().getName() 
                                            + " already declared");
         }
@@ -285,7 +335,7 @@ public class Typechecker {
         castVardecStmt.getExpression().setExpressionType(type);
     }
 
-    public void typecheckWhileStmt(final Statement whileStmt, final Map<Variable, Type> typeEnv)
+    public void typecheckWhileStmt(final Statement whileStmt, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
@@ -294,7 +344,7 @@ public class Typechecker {
 
     // Map of Expression classes to functions that return their types
     private static final Map<Class<? extends Expression>, 
-            TypecheckingFunction<Typechecker, Expression, Map<Variable, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
+            TypecheckingFunction<Typechecker, Expression, Map<String, Type>, Type>> EXP_TO_TYPE_FUNC = Map.of(
         BoolLiteralExp.class, (typechecker, exp, typeEnv) -> new BoolType(),
         FuncCallExp.class, Typechecker::typecheckFuncCallExp,
         IntLiteralExp.class, (typechecker, exp, typeEnv) -> new IntType(),
@@ -307,34 +357,34 @@ public class Typechecker {
         UnaryOpExp.class, Typechecker::typecheckUnaryOpExp
     );
 
-    public Type typecheckFuncCallExp(final Expression funcCallExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckFuncCallExp(final Expression funcCallExp, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         throw new TypecheckerException("Not implemented yet!");
         // Type test = new VoidType();
         // return test;
     }
 
-    public Type typecheckParenExp(final Expression parenExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckParenExp(final Expression parenExp, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         ParenExp castParenExp = (ParenExp)parenExp;
         // Get expression in the parentheses, typecheck that
         return typecheckExp(castParenExp.getExp(), typeEnv);
     }
 
-    public Type typecheckStructAllocExp(final Expression exp, final Map<Variable, Type> typeEnv)
+    public Type typecheckStructAllocExp(final Expression exp, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         final String beingParsed = "struct allocation expression";
         StructAllocExp structAllocExp = (StructAllocExp) exp;
 
         // Struct name should be a safe unwrap - the parser will have looked for an identifier after new, not a null token
         StructType structType = structAllocExp.getStructType();
-        StructName structName = structType.getStructName().get();
+        String structName = structType.getStructName().get().getName();
 
-        final String structWhereWeAre = "struct " + structName.structName;
+        final String structWhereWeAre = "struct " + structName;
         StructDef structDef = structNameToDef.get(structName);
 
         if (structDef == null) {
-            throwTypecheckerException(beingParsed, structWhereWeAre + " is not defined");
+            throwTypecheckerException(beingParsed, exp, structType, structWhereWeAre + " is not defined");
         }
 
         List<Param> structDefinedParams = structDef.getParams();
@@ -346,7 +396,10 @@ public class Typechecker {
         if (definedParameters != actualParameters) {
             final String errorSuffixFormat = "expected exactly %d allocation parameters for " + structWhereWeAre
                     + " but received %d allocation parameters";
-            throwTypecheckerException(beingParsed, String.format(errorSuffixFormat, definedParameters, actualParameters));
+            String errorSuffix = String.format(errorSuffixFormat, definedParameters, actualParameters);
+
+            AbstractSyntaxTreeNode child = actualParameters == 0 ? exp : structAllocParams.get(actualParameters - 1);
+            throwTypecheckerException(beingParsed, exp, child, errorSuffix);
         }
 
         for (int i = 0; i < definedParameters; i++) {
@@ -356,9 +409,9 @@ public class Typechecker {
             Variable definedVariable = definedParam.variable;
 
             // Check that the variable names match (in order)
-            if (!definedVariable.equals(allocationParam.var)) {
-                throwTypecheckerException(beingParsed, "expected allocation variable " + definedVariable.name
-                        + " but received " + allocationParam.var.name);
+            if (!definedVariable.getName().equals(allocationParam.var.getName())) {
+                throwTypecheckerException(beingParsed, exp, allocationParam, "expected allocation for variable `"
+                        + definedVariable.name + "` but received allocation for variable `" + allocationParam.var.name + "`");
             }
 
             Type definedType = definedParam.type;
@@ -367,8 +420,8 @@ public class Typechecker {
             Type allocationExpType = typecheckExp(allocationExp, typeEnv);
 
             // Check that the type defined matches the allocation expression's type
-            throwTypecheckerExceptionOnMismatchedTypes(beingParsed + " " + structWhereWeAre + " for allocation variable "
-                    + definedVariable.name, definedType, allocationExpType);
+            throwTypecheckerExceptionOnMismatchedTypes(beingParsed + " " + structWhereWeAre + " for allocation variable `"
+                    + definedVariable.name + "`", exp, allocationExpType, definedType, allocationExpType);
 
             // This parameter is safe!
         }
@@ -378,17 +431,12 @@ public class Typechecker {
         return structAllocExp.getStructType();
     }
 
-    public Type typecheckVarExp(final Expression variableExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckVarExp(final Expression expression, final Map<String, Type> typeEnv)
             throws TypecheckerException {
-        VariableExp castVarExp = (VariableExp)variableExp;
-        // Use optionals instead of this
-        Type type = typeEnv.get(castVarExp.getVar());
-        if (type == null) {
-            throw new TypecheckerException("Variable " + castVarExp.getVar().getName() 
-                                           + " not previously declared");
-        } else {
-            return type;
-        }
+        VariableExp variableExp = (VariableExp) expression;
+
+        return throwTypecheckerExceptionOnVariableNotExists("variable expression", variableExp, variableExp.getVar(),
+                typeEnv);
     }
 
     // Map of Enums to the types they can operate on
@@ -426,15 +474,21 @@ public class Typechecker {
     }};
 
     public boolean operandsAreValidType(List<Type> validTypes, Type type) {
-        return validTypes.contains(type);
+        for (Type validType : validTypes) {
+            if (validType.hasTypeEquality(type)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // In all cases, we need our types to match - what if LHT and RHT are both in the valid type list, but aren't the same?
     public boolean operandsAreValidType(List<Type> validTypes, Type leftHandType, Type rightHandType) {
-        return validTypes.contains(leftHandType) && validTypes.contains(rightHandType);
+        return operandsAreValidType(validTypes, leftHandType) && leftHandType.hasTypeEquality(rightHandType);
     }
 
-    public Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<Variable, Type> typeEnv)
+    public Type typecheckerBinOpExp(final Expression binaryOpExp, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         // Get the left and right hand sides
         BinaryOpExp castBinOpExp = (BinaryOpExp)binaryOpExp;
@@ -450,6 +504,7 @@ public class Typechecker {
         if (!OP_TO_OPERAND_TYPE.containsKey(op) || !OP_TO_EVAL_TYPE.containsKey(op)) {
             throw new TypecheckerException("Expected operator, but found: " + op.toString());
         }
+
         // Use the operator to decide what type the expressions should be
         List<Type> validOperandTypes = OP_TO_OPERAND_TYPE.get(op);
 
@@ -467,7 +522,7 @@ public class Typechecker {
         return evalType;
     }
 
-    public Type typecheckDotExp(final Expression exp, final Map<Variable, Type> typeEnv)
+    public Type typecheckDotExp(final Expression exp, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         final String beingParsed = "dot expression";
 
@@ -477,17 +532,18 @@ public class Typechecker {
         if (!(leftHandType instanceof StructType)) {
             final String errorSuffix = "expected a reference to a struct instance but received a type of "
                     + leftHandType.getParsedValue();
-            throwTypecheckerException(beingParsed, errorSuffix);
+            throwTypecheckerException(beingParsed, exp, leftHandType, errorSuffix);
         }
 
         StructType structType = (StructType) leftHandType;
         if (structType.isNullStruct()) {
             final String errorSuffix = "expected a reference to a struct instance but received raw reference to null";
-            throwTypecheckerException(beingParsed, errorSuffix);
+            throwTypecheckerException(beingParsed, exp, leftHandType, errorSuffix);
         }
 
         // By this point, if we evaluated an expression that is a type of struct, that struct should absolutely exist
-        StructDef structDef = structNameToDef.get(structType.getStructName().get());
+        String structName = structType.getStructName().get().getName();
+        StructDef structDef = structNameToDef.get(structName);
 
         Variable structField = dotExp.getRightVar();
         Type structFieldType = null;
@@ -501,15 +557,15 @@ public class Typechecker {
 
         // Check that the variable we used does exist as a parameter (or field) for the struct
         if (structFieldType == null) {
-            final String errorSuffix = "expected a valid struct field but received unknown field " + structField.name;
-            throwTypecheckerException(beingParsed, errorSuffix);
+            final String errorSuffix = "struct parameter " + structField.name + " is not defined on struct " + structType;
+            throwTypecheckerException(beingParsed, exp, structField, errorSuffix);
         }
 
         dotExp.setExpressionType(structFieldType);
         return structFieldType;
     }
 
-    public Type typecheckUnaryOpExp(final Expression exp, final Map<Variable, Type> typeEnv)
+    public Type typecheckUnaryOpExp(final Expression exp, final Map<String, Type> typeEnv)
             throws TypecheckerException {
         // This is VERY similar to parsing binary ops, probably could refactor at some point
         UnaryOpExp unaryOpExp = (UnaryOpExp) exp;
@@ -521,7 +577,11 @@ public class Typechecker {
         List<Type> validTypes = OP_TO_OPERAND_TYPE.get(op);
         if (!operandsAreValidType(validTypes, expressionType)) {
             // This should really be a more descriptive error message depending on the list of valid types
-            throwTypecheckerException(op.getSymbol() + " expression", "type mismatch");
+            String errorMessage = String.format("expected matching types of: {%s}", validTypes.stream()
+                            .map(Type::getNodeTypeDescriptor)
+                            .collect(Collectors.joining(", ")));
+
+            throwTypecheckerException(op.getSymbol() + " expression", exp, expressionType, errorMessage);
         }
 
         Type evalType = OP_TO_EVAL_TYPE.get(op);
@@ -531,14 +591,15 @@ public class Typechecker {
     }
 
     public Type typecheckExp(final Expression exp,
-                                    final Map<Variable, Type> typeEnv) throws TypecheckerException {
+                                    final Map<String, Type> typeEnv) throws TypecheckerException {
 
         // Get the expression's class
         Class<? extends Expression> expClass = exp.getClass();
 
         if (!EXP_TO_TYPE_FUNC.containsKey(expClass)) {
             // Do I throw an error here? This should be an expression and it isn't? IDK
-            throw new TypecheckerException("Expected expression, got: " + expClass.toString());
+            // Maybe an "unsupported exception" letting us know we did development bad is good here
+            throw new UnsupportedOperationException("Expected expression in map, got: " + expClass);
         }
 
         Type type = EXP_TO_TYPE_FUNC.get(expClass).apply(this, exp, typeEnv);

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -29,12 +29,18 @@ public class Typechecker {
 
     private final Map<StructName, StructDef> structNameToDef;
 
-    private Typechecker(Program program) {
+    private Typechecker(Program program) throws TypecheckerException {
         this.program = program;
 
         // Map all the struct definitions names to their AST definitions
-        this.structNameToDef = program.getStructDefs().stream()
+        // This throws an IllegalStateException if two structs share a name
+        // Should we catch it and throw a TypecheckerException?
+        try {
+            this.structNameToDef = program.getStructDefs().stream()
                 .collect(Collectors.toMap(StructDef::getStructName, structDef -> structDef));
+        } catch (IllegalStateException e) {
+            throw new TypecheckerException("Struct declarations share a name");
+        }
     }
 
     public static void typecheckProgram(Program program) throws TypecheckerException {

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -205,10 +205,7 @@ public class Typechecker {
             FunctionName funcName = funcDef.getFunctionName();
             Standardized<FunctionName> standardizedFuncName = Standardized.of(funcName);
 
-            // Because the order of the function definitions matters in C, I'm going to
-            // Add the function definition first (because recursion is allowed)
-            // MAKE THIS CHECK FOR NEW FUNCTION SIGNATURE RATHER THAN FUNCTION NAME
-            // CAN I STANDARDIZE A WHOLE FUNCTION SIGNATURE
+            // Check if the function name is already in the map
             if (!functionNameToDef.containsKey(standardizedFuncName)) {
                 functionNameToDef.put(standardizedFuncName, new ArrayList<>(List.of(funcDef)));
             } else {

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -410,11 +410,11 @@ public class Typechecker {
             throws TypecheckerException {
         String beingParsed = "return statement";
         // Get the first type's class
-        Class<? extends Type> returnType = returnTypes.get(0).getClass();
+        Type returnType = returnTypes.get(0);
 
         // Check that this doesn't conflict with the other return types
         for (Type type : returnTypes) {
-            if (!type.getClass().equals(returnType)) {
+            if (!type.hasTypeEquality(returnType)) {
                 // Throw error if there is more than one return type
                 // throwTypecheckerExceptionOnMismatchedTypes(beingParsed, parent, 
                 //         firstType, type, returnTypes.get(0));
@@ -487,8 +487,8 @@ public class Typechecker {
     );
 
     // Returns true if the arguments (commaExpList) types match the param list types
-    public boolean argsMatchSignature(final List<Expression> commaExpList, final List<Param> paramList, 
-            final Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
+    public boolean argsMatchSignature(final List<Expression> commaExpList, final List<Param> paramList,
+                                                  final Map<Standardized<Variable>, Type> typeEnv) throws TypecheckerException {
         // If the arg list and param list are not the same size
         if (commaExpList.size() != paramList.size()) {
             return false;
@@ -498,10 +498,11 @@ public class Typechecker {
             // Get the argument's type
             Type argType = typecheckExp(commaExpList.get(i), typeEnv);
             // If an arg type doesn't match a param type, return false
-            if (!argType.getClass().equals(paramList.get(i).getType().getClass())) {
+            if (!argType.hasTypeEquality(paramList.get(i).getType())) {
                 return false;
             }
         }
+
         // All of the types match, return true
         return true;
     }

--- a/src/main/java/refraff/typechecker/Typechecker.java
+++ b/src/main/java/refraff/typechecker/Typechecker.java
@@ -1,17 +1,28 @@
 package refraff.typechecker;
 
+import refraff.parser.ParseResult;
 import refraff.parser.Program;
 import refraff.parser.Variable;
 import refraff.parser.struct.Param;
 import refraff.parser.struct.StructDef;
 import refraff.parser.struct.StructName;
-import refraff.parser.type.StructType;
-import refraff.parser.type.Type;
-import refraff.parser.type.VoidType;
+import refraff.parser.type.*;
+import refraff.tokenizer.IdentifierToken;
+import refraff.tokenizer.Token;
+import refraff.tokenizer.reserved.BoolToken;
+import refraff.tokenizer.reserved.IntToken;
+import refraff.tokenizer.reserved.VoidToken;
+import refraff.tokenizer.symbol.*;
+import refraff.parser.expression.primaryExpression.*;
+import refraff.parser.operator.OperatorEnum;
+import refraff.parser.expression.*;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class Typechecker {
@@ -79,4 +90,117 @@ public class Typechecker {
         throw new TypecheckerException(onVariableDeclaration + errorMessage);
     }
 
+    // Map of Expression classes to functions that return their types
+    private static final Map<Class<? extends Expression>, 
+            TypecheckingFunction<Expression, Map<Variable, Type>, Type>> EXP_TO_TYPE = Map.of(
+        BoolLiteralExp.class, (exp, typeEnv) -> new BoolType(),
+        FuncCallExp.class, Typechecker::typecheckFuncCallExp,
+        IntLiteralExp.class, (exp, typeEnv) -> new IntType(),
+        NullExp.class, (exp, typeEnv) -> new VoidType(),
+        ParenExp.class, Typechecker::typecheckParenExp,
+        StructAllocExp.class, Typechecker::typecheckStructAllocExp,
+        VariableExp.class, Typechecker::typecheckVarExp,
+        BinaryOpExp.class, Typechecker::typecheckerBinOpExp,
+        DotExp.class, Typechecker::typecheckDotExp,
+        UnaryOpExp.class, Typechecker::typecheckUnaryOpExp
+    );
+
+    public static Type typecheckFuncCallExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckParenExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckStructAllocExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckVarExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckerBinOpExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckDotExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckUnaryOpExp(final Expression binExp, final Map<Variable, Type> typeEnv)
+            throws TypecheckerException {
+        Type test = new VoidType();
+        return test;
+    }
+
+    public static Type typecheckExp(final Expression exp,
+                                    final Map<Variable, Type> typeEnv) throws TypecheckerException {
+
+        // Get the expression's class
+        Class<? extends Expression> expClass = exp.getClass();
+
+        if (!EXP_TO_TYPE.containsKey(expClass)) {
+            // Do I throw an error here? This should be an expression and it isn't? IDK
+            throw new TypecheckerException("Expected expression, got: " + expClass.toString());
+        }
+
+        Type type = EXP_TO_TYPE.get(expClass).apply(exp, typeEnv);
+        return type;
+    
+
+        // if (exp instanceof IntLiteralExp) {
+        //     return new IntType();
+        // } else if (exp instanceof BoolLiteralExp) {
+        //     return new BoolType();
+        // } else if (exp instanceof VariableExp) {
+        //     final Variable variable = ((VariableExp)exp).getVar();
+        //     if (typeEnv.get(variable) {
+        //         return typeEnv.get(variable);
+        //     } else {
+        //         throw new TypecheckerException("Variable not in scope: " + variable.name);
+        //     }
+        // } else if (exp instanceof BinaryOpExp) {
+        //     final BinaryOpExp asBin = (BinaryOpExp)asBin;
+        //     return typecheckBin(asBin, typeEnv);
+        // } else {
+        //     assert(false);
+        //     throw new TypecheckerException("Haven't implemented expression typechecking yet");
+        // }
+    }
+
+
+
+
+
+
+    /*
+     * private final static Map<Token, OperatorEnum> TOKEN_TO_OP = Map.ofEntries(
+        new SimpleImmutableEntry<>(new OrToken(), OperatorEnum.OR),
+        new SimpleImmutableEntry<>(new AndToken(), OperatorEnum.AND),
+        new SimpleImmutableEntry<>(new DoubleEqualsToken(), OperatorEnum.DOUBLE_EQUALS),
+        new SimpleImmutableEntry<>(new NotEqualsToken(), OperatorEnum.NOT_EQUALS),
+        new SimpleImmutableEntry<>(new LessThanEqualsToken(), OperatorEnum.LESS_THAN_EQUALS),
+        new SimpleImmutableEntry<>(new GreaterThanEqualsToken(), OperatorEnum.GREATER_THAN_EQUALS),
+        new SimpleImmutableEntry<>(new PlusToken(), OperatorEnum.PLUS),
+        new SimpleImmutableEntry<>(new MinusToken(), OperatorEnum.MINUS),
+        new SimpleImmutableEntry<>(new MultiplyToken(), OperatorEnum.MULTIPLY),
+        new SimpleImmutableEntry<>(new DivisionToken(), OperatorEnum.DIVISION),
+        new SimpleImmutableEntry<>(new NotToken(), OperatorEnum.NOT),
+        new SimpleImmutableEntry<>(new DotToken(), OperatorEnum.DOT)
+    );
+     */
 }

--- a/src/main/java/refraff/typechecker/TypecheckingFunction.java
+++ b/src/main/java/refraff/typechecker/TypecheckingFunction.java
@@ -1,9 +1,9 @@
 package refraff.typechecker;
 
 @FunctionalInterface
-public interface TypecheckingFunction<T, U, R> {
+public interface TypecheckingFunction<T, U, V, R> {
     
-    R apply(T t, U u) throws TypecheckerException;
+    R apply(T t, U u, V v) throws TypecheckerException;
 
 }
 

--- a/src/main/java/refraff/typechecker/TypecheckingFunction.java
+++ b/src/main/java/refraff/typechecker/TypecheckingFunction.java
@@ -1,11 +1,5 @@
 package refraff.typechecker;
 
-// import java.util.Map;
-
-// import refraff.parser.Variable;
-// import refraff.parser.expression.Expression;
-// import refraff.parser.type.Type;
-
 @FunctionalInterface
 public interface TypecheckingFunction<T, U, R> {
     

--- a/src/main/java/refraff/typechecker/TypecheckingFunction.java
+++ b/src/main/java/refraff/typechecker/TypecheckingFunction.java
@@ -1,5 +1,11 @@
 package refraff.typechecker;
 
+// import java.util.Map;
+
+// import refraff.parser.Variable;
+// import refraff.parser.expression.Expression;
+// import refraff.parser.type.Type;
+
 @FunctionalInterface
 public interface TypecheckingFunction<T, U, R> {
     

--- a/src/main/java/refraff/typechecker/TypecheckingFunction.java
+++ b/src/main/java/refraff/typechecker/TypecheckingFunction.java
@@ -1,0 +1,9 @@
+package refraff.typechecker;
+
+@FunctionalInterface
+public interface TypecheckingFunction<T, U, R> {
+    
+    R apply(T t, U u) throws TypecheckerException;
+
+}
+

--- a/src/main/java/refraff/typechecker/TypecheckingVoidFunction.java
+++ b/src/main/java/refraff/typechecker/TypecheckingVoidFunction.java
@@ -1,8 +1,8 @@
 package refraff.typechecker;
 
 @FunctionalInterface
-public interface TypecheckingVoidFunction<T, U> {
+public interface TypecheckingVoidFunction<T, U, V> {
 
-    void apply(T t, U u) throws TypecheckerException;
+    void apply(T t, U u, V v) throws TypecheckerException;
 
 }

--- a/src/main/java/refraff/typechecker/TypecheckingVoidFunction.java
+++ b/src/main/java/refraff/typechecker/TypecheckingVoidFunction.java
@@ -1,0 +1,8 @@
+package refraff.typechecker;
+
+@FunctionalInterface
+public interface TypecheckingVoidFunction<T, U> {
+
+    void apply(T t, U u) throws TypecheckerException;
+
+}

--- a/src/test/java/refraff/SourceTest.java
+++ b/src/test/java/refraff/SourceTest.java
@@ -1,0 +1,78 @@
+package refraff;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SourceTest {
+
+    private static final Class<? extends Exception> SOURCE_EXCEPTION_TYPE = IllegalArgumentException.class;
+
+    @Test
+    public void testFromSourceWithZeroSourcesThrowsException() {
+        assertThrows(SOURCE_EXCEPTION_TYPE, Source::fromSources);
+    }
+
+    @Test
+    public void testFromSourceWithOneSourceEqualsOriginalSource() {
+        assertDoesNotThrow(() -> {
+            Source source = Source.DEFAULT_TESTING_SOURCE;
+            assertEquals(source, Source.fromSources(source));
+        });
+    }
+
+    @Test
+    public void testFromSourceWithMultipleSources() {
+        // int x = true;
+        assertDoesNotThrow(() -> {
+            Source source1 = new Source("int", new SourcePosition(1, 1), new SourcePosition(1, 4));
+            Source source2 = new Source("x", new SourcePosition(1, 5), new SourcePosition(1, 6));
+            Source source3 = new Source("=", new SourcePosition(1, 7), new SourcePosition(1, 8));
+            Source source4 = new Source("true", new SourcePosition(1, 9), new SourcePosition(1, 13));
+            Source source5 = new Source(";", new SourcePosition(1, 13), new SourcePosition(1, 14));
+
+            Source expectedSource = new Source("int x = true;", source1.getStartPosition(), source5.getEndPosition());
+            Source actualSource = Source.fromSources(source1, source2, source3, source4, source5);
+
+            assertEquals(expectedSource, actualSource);
+        });
+    }
+
+    @Test
+    public void testFromSourceWithMultilineSources() {
+        String expectedInput = """
+                func foo(int a): int {
+                  return a + 2;
+                }""";
+
+
+        // func foo(int a): int {
+        Source funcSource = new Source("func", new SourcePosition(1, 1), new SourcePosition(1, 5));
+        Source fooSource = new Source("foo", new SourcePosition(1, 6), new SourcePosition(1, 9));
+        Source leftParenSource = new Source("(", new SourcePosition(1, 9), new SourcePosition(1, 10));
+        Source intParamSource = new Source("int", new SourcePosition(1, 10), new SourcePosition(1, 13));
+        Source aParamSource = new Source("a", new SourcePosition(1, 14), new SourcePosition(1, 15));
+        Source rightParenSource = new Source(")", new SourcePosition(1, 15), new SourcePosition(1, 16));
+        Source colonSource = new Source(":", new SourcePosition(1, 16), new SourcePosition(1, 17));
+        Source intReturnSource = new Source("int", new SourcePosition(1, 18), new SourcePosition(1, 21));
+        Source leftBraceSource = new Source("{", new SourcePosition(1, 22), new SourcePosition(1, 23));
+
+        // <space><space>return a + 2;
+        Source returnSource = new Source("return", new SourcePosition(2, 3), new SourcePosition(2, 9));
+        Source aSource = new Source("a", new SourcePosition(2, 10), new SourcePosition(2, 11));
+        Source plusSource = new Source("+", new SourcePosition(2, 12), new SourcePosition(2, 13));
+        Source twoSource = new Source("2", new SourcePosition(2, 14), new SourcePosition(2, 15));
+        Source semicolonSource = new Source(";", new SourcePosition(2, 15), new SourcePosition(2, 16));
+
+        // }
+        Source rightBrace = new Source("}", new SourcePosition(3, 1), new SourcePosition(3, 2));
+
+        Source expectedSource = new Source(expectedInput, funcSource.getStartPosition(), rightBrace.getEndPosition());
+        Source actualSource = Source.fromSources(funcSource, fooSource, leftParenSource, intParamSource,
+                aParamSource, rightParenSource, colonSource, intReturnSource, leftBraceSource, returnSource,
+                aSource, plusSource, twoSource, semicolonSource, rightBrace);
+
+        assertEquals(expectedSource, actualSource);
+    }
+
+}

--- a/src/test/java/refraff/parser/ParserTest.java
+++ b/src/test/java/refraff/parser/ParserTest.java
@@ -1043,7 +1043,10 @@ public class ParserTest {
         IntType returnType = new IntType();
         returnType.setSource(intReturnSource);
 
-        VariableExp aBodyVariableExp = new VariableExp("a");
+        Variable aBodyVariable = new Variable("a");
+        aBodyVariable.setSource(aSource);
+
+        VariableExp aBodyVariableExp = new VariableExp(aBodyVariable);
         aBodyVariableExp.setSource(aSource);
 
         IntLiteralExp twoExp = new IntLiteralExp(2);

--- a/src/test/java/refraff/parser/ParserTest.java
+++ b/src/test/java/refraff/parser/ParserTest.java
@@ -328,7 +328,7 @@ public class ParserTest {
         );
 
         Expression intLiteral6 = new IntLiteralExp(6);
-        Expression varCount = new VariableExp("count");
+        Expression varCount = new VariableExp(new Variable("count"));
         Expression binOpDoubleEquals = new BinaryOpExp(varCount, OperatorEnum.DOUBLE_EQUALS, intLiteral6);
         Expression parenExp = new ParenExp(binOpDoubleEquals);
         Variable varIsTrue = new Variable("isTrue");
@@ -402,7 +402,7 @@ public class ParserTest {
         final List<FunctionDef> functionDefs = new ArrayList<>();
         final List<Statement> statements = new ArrayList<>();
 
-        DotExp dotExp = new DotExp(new VariableExp("example"), new Variable("result"));
+        DotExp dotExp = new DotExp(new VariableExp(new Variable("example")), new Variable("result"));
 
         statements.add(new AssignStmt(
                 new Variable("retval"),
@@ -434,7 +434,7 @@ public class ParserTest {
         final List<FunctionDef> functionDefs = new ArrayList<>();
         final List<Statement> statements = new ArrayList<>();
 
-        DotExp dotExp0 = new DotExp(new VariableExp("example"), new Variable("result"));
+        DotExp dotExp0 = new DotExp(new VariableExp(new Variable("example")), new Variable("result"));
         DotExp dotExp1 = new DotExp(dotExp0, new Variable("value"));
         DotExp dotExp2 = new DotExp(dotExp1, new Variable("rest"));
         DotExp dotExp3 = new DotExp(dotExp2, new Variable("next"));
@@ -463,7 +463,7 @@ public class ParserTest {
         final List<FunctionDef> functionDefs = new ArrayList<>();
         final List<Statement> statements = new ArrayList<>();
 
-        Expression leftExp = new VariableExp("retval");
+        Expression leftExp = new VariableExp(new Variable("retval"));
         Expression rightExp = new IntLiteralExp(2);
 
         BinaryOpExp multExp = new BinaryOpExp(leftExp, OperatorEnum.MULTIPLY, rightExp);
@@ -492,12 +492,12 @@ public class ParserTest {
             new RightParenToken(), new OrToken(), new FalseToken(), new SemicolonToken()
         );
 
-        Expression varExpOtherCount = new VariableExp("otherCount");
+        Expression varExpOtherCount = new VariableExp(new Variable("otherCount"));
         Variable varValue = new Variable("value");
         DotExp dotExp = new DotExp(varExpOtherCount, varValue);
         Expression intLiteral5 = new IntLiteralExp(5);
         Expression binOpDivide = new BinaryOpExp(dotExp, OperatorEnum.DIVISION, intLiteral5);
-        Expression varExpCount = new VariableExp("count");
+        Expression varExpCount = new VariableExp(new Variable("count"));
         Expression binOpMinus = new BinaryOpExp(varExpCount, OperatorEnum.MINUS, binOpDivide);
 
         Expression intLiteral3 = new IntLiteralExp(3);
@@ -508,7 +508,7 @@ public class ParserTest {
 
         Expression binOpGte = new BinaryOpExp(binOpAdd, OperatorEnum.GREATER_THAN_EQUALS, binOpMinus);
         Expression parenGteExp = new ParenExp(binOpGte);
-        Expression varIsTrue = new VariableExp("isTrue");
+        Expression varIsTrue = new VariableExp(new Variable("isTrue"));
         Expression notOpExp = new UnaryOpExp(OperatorEnum.NOT, varIsTrue);
 
         Expression andExp = new BinaryOpExp(notOpExp, OperatorEnum.AND, parenGteExp);
@@ -610,7 +610,7 @@ public class ParserTest {
         final List<FunctionDef> functionDefs = new ArrayList<>();
         final List<Statement> statements = new ArrayList<>();
 
-        VariableExp variableList = new VariableExp("list");
+        VariableExp variableList = new VariableExp(new Variable("list"));
         CommaExp commaExp = new CommaExp(Arrays.asList(variableList));
         FunctionName funcNameLength = new FunctionName("length"); 
         FuncCallExp funcCallExp = new FuncCallExp(funcNameLength, commaExp);
@@ -643,8 +643,8 @@ public class ParserTest {
 
 
         BoolLiteralExp boolLitTrue = new BoolLiteralExp(true);
-        VariableExp varExpIndex = new VariableExp("index");
-        DotExp dotExp = new DotExp(new VariableExp("node"), new Variable("next"));
+        VariableExp varExpIndex = new VariableExp(new Variable("index"));
+        DotExp dotExp = new DotExp(new VariableExp(new Variable("node")), new Variable("next"));
         List<Expression> argsList = Arrays.asList(dotExp, varExpIndex, boolLitTrue);
         CommaExp commaExp = new CommaExp(argsList);
         FunctionName funcNameLength = new FunctionName("length");
@@ -657,6 +657,8 @@ public class ParserTest {
                 parser.parseProgram(0));
     }
 
+
+    // Test invalid inputs
 
     private void testProgramParsesWithException(Token... tokens) {
         assertThrows(ParserException.class, () -> parseProgram(tokens));

--- a/src/test/java/refraff/parser/ParserTest.java
+++ b/src/test/java/refraff/parser/ParserTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.*;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import refraff.Source;
@@ -23,6 +24,9 @@ import refraff.parser.statement.*;
 import refraff.parser.struct.*;
 import refraff.parser.operator.*;
 import refraff.parser.expression.primaryExpression.*;
+import refraff.typechecker.Typechecker;
+import refraff.typechecker.TypecheckerException;
+import refraff.util.ResourceUtil;
 
 
 public class ParserTest {
@@ -1070,6 +1074,20 @@ public class ParserTest {
         program.setSource(functionDef.getSource());
 
         testProgramMatchesExpectedResult(program, sourcedTokens);
+    }
+
+
+    // Integration test
+
+    @Test
+    public void testTokenizeParseProgramWithoutException() {
+        String input = ResourceUtil.readProgramInputFile();
+        try {
+            List<Sourced<Token>> sourcedTokens = new Tokenizer(input).tokenize();
+            Parser.parseProgram(sourcedTokens);
+        } catch (TokenizerException | ParserException ex) {
+            Assert.fail(ex.toString());
+        }
     }
 
 }

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -498,20 +498,36 @@ public class TypecheckerTest {
 
     // Tests for function definitions
     // Test function with mutliple return statements (when if/else typechecking is implemented)
-    // Test function with different typed return statements throws error
+    // Test function with different typed return statements throws error (after if/else)
+    // Should we check for return reachability?
 
-    // private void testFunctionDefinitionWithWileLoop() {
-    //     /*
-    //     *  func length(Node list): int {
-    //             int retval = 0;
-    //             while (list != null) {
-    //                 retval = retval + 1;
-    //                 list = list.rest;
-    //             }
-    //         return retval;
-    //         }
-    //     */
-    // }
+
+    @Test
+    public void testStructNameAsParamType() {
+        /*
+         * struct A {
+         *   A a;
+         * }
+         * 
+         * func foo(A a) : void {
+         *   return;
+         * }
+         */
+        StructDef structDef = new StructDef(getStructName("A"), List.of(
+                new Param(getStructType("A"), getVariable("a"))));
+    
+        FunctionBody funcBody = new FunctionBody(List.of(new ReturnStmt()));
+        Param param = new Param(getStructType("A"), getVariable("a"));
+        FunctionDef funcDef = new FunctionDef(
+                getFunctionName("foo"),
+                List.of(param),
+                getVoidType(),
+                funcBody
+        );
+
+        Program program = new Program(List.of(structDef), List.of(funcDef), List.of());
+        testDoesNotThrowTypecheckerException(program);
+    }
 
 
     // Test invalid inputs

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -33,6 +33,7 @@ import refraff.parser.expression.primaryExpression.*;
 import refraff.parser.operator.OperatorEnum;
 import refraff.parser.statement.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertThrows;
@@ -89,6 +90,22 @@ public class TypecheckerTest {
          */
         Statement boolLitExpStmtTrue = new ExpressionStmt(new BoolLiteralExp(true));
         Program program = new Program(List.of(), List.of(), List.of(boolLitExpStmtTrue));
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    @Test
+    public void testVardecExpAndVarExp() {
+        /*
+         * int foo = 6;
+         * foo;
+         */
+        Statement vardecStmt = new VardecStmt(
+            new IntType(), 
+            new Variable("foo"),
+            new IntLiteralExp(6)
+        );
+        Statement varExpStmt = new ExpressionStmt(new VariableExp(new Variable("foo")));
+        Program program = new Program(List.of(), List.of(), List.of(vardecStmt, varExpStmt));
         testDoesNotThrowTypecheckerException(program);
     }
 
@@ -205,6 +222,33 @@ public class TypecheckerTest {
         Statement statement = new ExpressionStmt(orExp);
 
         Program invalidProgram = new Program(List.of(), List.of(), List.of(statement));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testExpStmtWithoutVardecThrowsException() {
+        /*
+         * foo;
+         */
+
+        Statement varExpStmt = new ExpressionStmt(new VariableExp(new Variable("foo")));
+        Program invalidProgram = new Program(List.of(), List.of(), List.of(varExpStmt));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testStructNameIsReusedInVardec() {
+        /*
+         * struct foo = {};
+         * int foo = 6;
+         */
+
+        StructDef structDef = new StructDef(new StructName("foo"), new ArrayList<Param>());
+        Statement vardecStmt = new VardecStmt(
+                new IntType(),
+                new Variable("foo"),
+                new IntLiteralExp(6));
+        Program invalidProgram = new Program(List.of(structDef), List.of(), List.of(vardecStmt));
         testThrowsTypecheckerException(invalidProgram);
     }
 }

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -6,10 +6,8 @@ import org.junit.jupiter.api.Disabled;
 import refraff.Sourced;
 import refraff.parser.*;
 import refraff.parser.struct.*;
-import refraff.parser.type.BoolType;
-import refraff.parser.type.IntType;
-import refraff.parser.type.StructType;
-import refraff.parser.type.VoidType;
+import refraff.parser.type.*;
+import refraff.parser.function.*;
 import refraff.parser.expression.*;
 import refraff.parser.expression.primaryExpression.*;
 import refraff.parser.operator.OperatorEnum;
@@ -20,6 +18,7 @@ import refraff.tokenizer.TokenizerException;
 import refraff.util.ResourceUtil;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -335,7 +334,50 @@ public class TypecheckerTest {
         testDoesNotThrowTypecheckerException(program);
     }
 
-    
+    @Test
+    public void testFunctionDefinitionReturnsBool() {
+        /*
+        *  func alwaysTrue(): bool {
+        *       return true;
+        *   }
+        */
+
+        Expression boolTrue = new BoolLiteralExp(true);
+        Statement returnStmtTrue = new ReturnStmt(boolTrue);
+        StmtBlock funcBody = new StmtBlock(List.of(returnStmtTrue));
+        FunctionDef funcDef = new FunctionDef(
+            new FunctionName("alwaysTrue"),
+            new ArrayList<Param>(),
+            getBoolType(),
+            funcBody
+        );
+
+        Program program = new Program(List.of(), List.of(funcDef), List.of());
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    // Tests for function definitions
+    // Test that a function that returns another function call type checks that
+    // Test that a function that returns another function call that returns the wrong type throws an error
+    // Test a function with a parameter
+    // Test a function with two parameters
+    // Test a function with void doesn't and doesn't return anything doesn't throw an error
+    // Test a function with void type and returns something throws an error
+    // Test two function with the same name but different signatures
+
+    // private void testFunctionDefinitionWithWileLoop() {
+    //     /*
+    //     *  func length(Node list): int {
+    //             int retval = 0;
+    //             while (list != null) {
+    //                 retval = retval + 1;
+    //                 list = list.rest;
+    //             }
+    //         return retval;
+    //         }
+    //     */
+    // }
+
 
     // Test invalid inputs
 
@@ -621,22 +663,6 @@ public class TypecheckerTest {
         testThrowsTypecheckerException(invalidProgram);
     }
 
-//    @Test
-//    public void testStructNameIsReusedInVardecThrowsException() {
-//        /*
-//         * struct foo = {};
-//         * int foo = 6;
-//         */
-//
-//        StructDef structDef = new StructDef(new StructName("foo"), new ArrayList<Param>());
-//        Statement vardecStmt = new VardecStmt(
-//                getIntType(),
-//                getVariable("foo"),
-//                new IntLiteralExp(6));
-//        Program invalidProgram = new Program(List.of(structDef), List.of(), List.of(vardecStmt));
-//        testThrowsTypecheckerException(invalidProgram);
-//    }
-
     @Test
     public void testAssignStmtWithNoVariableInScopeThrowsException() {
         /*
@@ -710,6 +736,28 @@ public class TypecheckerTest {
         Statement statement = new ExpressionStmt(expression);
 
         Program invalidProgram = new Program(List.of(), List.of(), List.of(statement));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testFunctionDefinitionReturnsIntInsteadOfBoolThrowsException() {
+        /*
+        *  func alwaysTrue(): bool {
+        *       return 0;
+        *   }
+        */
+
+        Expression intLiteral0 = new IntLiteralExp(0);
+        Statement returnStmt0 = new ReturnStmt(intLiteral0);
+        FunctionBody funcBody = new FunctionBody(List.of(returnStmt0));
+        FunctionDef funcDef = new FunctionDef(
+            new FunctionName("alwaysTrue"),
+            new ArrayList<Param>(),
+            getBoolType(),
+            funcBody
+        );
+
+        Program invalidProgram = new Program(List.of(), List.of(funcDef), List.of());
         testThrowsTypecheckerException(invalidProgram);
     }
 

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -253,6 +253,69 @@ public class TypecheckerTest {
     }
 
     @Test
+    public void testEmptyWhileStmt() {
+        /*
+         * while (true) {
+         *
+         * }
+         */
+        Statement whileStmt = new WhileStmt(new BoolLiteralExp(true), new StmtBlock());
+
+        Program program = new Program(List.of(), List.of(), List.of(whileStmt));
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+
+    @Test
+    public void testNonEmptyWhileStmt() {
+        /*
+         * int x = 7;
+         * while (x <= 10)
+         *     x = x + 1;
+         */
+        Variable x = getVariable("x");
+        VariableExp xExp = new VariableExp(x);
+
+        Statement vardec = new VardecStmt(getIntType(), x, new IntLiteralExp(7));
+
+        Expression whileCondition = new BinaryOpExp(xExp, OperatorEnum.LESS_THAN_EQUALS, new IntLiteralExp(10));
+        Statement whileBody = new AssignStmt(x, new BinaryOpExp(xExp, OperatorEnum.PLUS, new IntLiteralExp(1)));
+
+        Statement whileStmt = new WhileStmt(whileCondition, whileBody);
+
+        Program program = new Program(List.of(), List.of(), List.of(vardec, whileStmt));
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    @Test
+    public void testBreakStmt() {
+        /*
+         * while (true)
+         *    break;
+         */
+        Statement whileStmt = new WhileStmt(new BoolLiteralExp(true), new BreakStmt());
+
+        Program program = new Program(List.of(), List.of(), List.of(whileStmt));
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    @Test
+    public void testNestedBreakStmt() {
+        /*
+         * while (true) {
+         *     while (false)
+         *         break;
+         *    break;
+         * }
+         */
+        Statement whileInner = new WhileStmt(new BoolLiteralExp(false), new BreakStmt());
+        Statement whileOuter = new WhileStmt(new BoolLiteralExp(true), new StmtBlock(List.of(whileInner, new BreakStmt())));
+
+        Program program = new Program(List.of(), List.of(), List.of(whileOuter));
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    @Test
     public void testLogicalNotExpStmt() {
         // !true;
         Expression expression = new UnaryOpExp(OperatorEnum.NOT, new BoolLiteralExp(true));
@@ -957,6 +1020,21 @@ public class TypecheckerTest {
         Statement assign = new AssignStmt(getVariable("a"), new IntLiteralExp(3));
 
         Program invalidProgram = new Program(List.of(), List.of(), List.of(vardec, assign));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testWhileStmtNonBoolConditionThrowsException() {
+        // while (7) {}
+        Program invalidProgram = new Program(List.of(), List.of(), List.of(
+                new WhileStmt(new IntLiteralExp(7), new StmtBlock())));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testBreakStmtNotInLoopThrowsException() {
+        // break;
+        Program invalidProgram = new Program(List.of(), List.of(), List.of(new BreakStmt()));
         testThrowsTypecheckerException(invalidProgram);
     }
 

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -10,6 +10,28 @@ import refraff.parser.type.BoolType;
 import refraff.parser.type.IntType;
 import refraff.parser.type.StructType;
 import refraff.parser.type.VoidType;
+import refraff.tokenizer.IdentifierToken;
+import refraff.tokenizer.IntLiteralToken;
+import refraff.tokenizer.Token;
+import refraff.tokenizer.reserved.BoolToken;
+import refraff.tokenizer.reserved.FalseToken;
+import refraff.tokenizer.symbol.AndToken;
+import refraff.tokenizer.symbol.AssignmentToken;
+import refraff.tokenizer.symbol.DivisionToken;
+import refraff.tokenizer.symbol.DotToken;
+import refraff.tokenizer.symbol.GreaterThanEqualsToken;
+import refraff.tokenizer.symbol.LeftParenToken;
+import refraff.tokenizer.symbol.MinusToken;
+import refraff.tokenizer.symbol.MultiplyToken;
+import refraff.tokenizer.symbol.NotToken;
+import refraff.tokenizer.symbol.OrToken;
+import refraff.tokenizer.symbol.PlusToken;
+import refraff.tokenizer.symbol.RightParenToken;
+import refraff.tokenizer.symbol.SemicolonToken;
+import refraff.parser.expression.*;
+import refraff.parser.expression.primaryExpression.*;
+import refraff.parser.operator.OperatorEnum;
+import refraff.parser.statement.*;
 
 import java.util.List;
 
@@ -57,6 +79,52 @@ public class TypecheckerTest {
         ));
 
         Program program = new Program(List.of(structDef1, structDef2), List.of(), List.of());
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    @Test
+    public void testExpWithBool() {
+        /*
+         * true;
+         */
+        Statement boolLitExpStmtTrue = new ExpressionStmt(new BoolLiteralExp(true));
+        Program program = new Program(List.of(), List.of(), List.of(boolLitExpStmtTrue));
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    @Test
+    public void testExpWithBinOpExp() {
+        /*
+         * (!isTrue && (4 + 3 * 7 >= count - otherCount.value / 5)) || false;
+         */
+
+        Expression varExpOtherCount = new VariableExp(new Variable("otherCount"));
+        Variable varValue = new Variable("value");
+        DotExp dotExp = new DotExp(varExpOtherCount, varValue);
+        Expression intLiteral5 = new IntLiteralExp(5);
+        Expression binOpDivide = new BinaryOpExp(dotExp, OperatorEnum.DIVISION, intLiteral5);
+        Expression varExpCount = new VariableExp(new Variable("count"));
+        Expression binOpMinus = new BinaryOpExp(varExpCount, OperatorEnum.MINUS, binOpDivide);
+
+        Expression intLiteral3 = new IntLiteralExp(3);
+        Expression intLiteral7 = new IntLiteralExp(7);
+        Expression binOpMult = new BinaryOpExp(intLiteral3, OperatorEnum.MULTIPLY, intLiteral7);
+        Expression intLiteral4 = new IntLiteralExp(4);
+        Expression binOpAdd = new BinaryOpExp(intLiteral4, OperatorEnum.PLUS, binOpMult);
+
+        Expression binOpGte = new BinaryOpExp(binOpAdd, OperatorEnum.GREATER_THAN_EQUALS, binOpMinus);
+        Expression parenGteExp = new ParenExp(binOpGte);
+        Expression varIsTrue = new VariableExp(new Variable("isTrue"));
+        Expression notOpExp = new UnaryOpExp(OperatorEnum.NOT, varIsTrue);
+
+        Expression andExp = new BinaryOpExp(notOpExp, OperatorEnum.AND, parenGteExp);
+        Expression falseExp = new BoolLiteralExp(false);
+        Expression parenAndExp = new ParenExp(andExp);
+        Expression orExp = new BinaryOpExp(parenAndExp, OperatorEnum.OR, falseExp);
+
+        Statement statement = new ExpressionStmt(orExp);
+
+        Program program = new Program(List.of(), List.of(), List.of(statement));
         testDoesNotThrowTypecheckerException(program);
     }
 

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -26,6 +26,11 @@ public class TypecheckerTest {
 
     @Test
     public void testStructDefWithRecursiveStructVariableType() {
+        /*
+         * struct A {
+         *   A a;
+         * }
+         */
         StructDef structDef = new StructDef(new StructName("A"), List.of(
                 new Param(new StructType(new StructName("A")), new Variable("a"))
         ));
@@ -36,6 +41,12 @@ public class TypecheckerTest {
 
     @Test
     public void testStructDefWithOtherStructVariableType() {
+        /*
+         * struct A {
+         *   int foo;
+         *   bool bar;
+         * }
+         */
         StructDef structDef1 = new StructDef(new StructName("A"), List.of(
                 new Param(new IntType(), new Variable("foo")),
                 new Param(new BoolType(), new Variable("bar"))
@@ -49,6 +60,8 @@ public class TypecheckerTest {
         testDoesNotThrowTypecheckerException(program);
     }
 
+    
+
     // Test invalid inputs
 
     private void testThrowsTypecheckerException(Program invalidProgram) {
@@ -57,6 +70,11 @@ public class TypecheckerTest {
 
     @Test
     public void testStructDefWithVoidTypeVariable() {
+        /*
+         * struct A {
+         *   Void b;
+         * }
+         */
         StructDef invalidStructDef = new StructDef(new StructName("A"), List.of(
                 new Param(new VoidType(), new Variable("b"))
         ));
@@ -67,6 +85,11 @@ public class TypecheckerTest {
 
     @Test
     public void testStructDefWithUndefinedStructTypeVariable() {
+        /*
+         * struct A {
+         *   B b;
+         * }
+         */
         StructDef invalidStructDef = new StructDef(new StructName("A"), List.of(
                 new Param(new StructType(new StructName("B")), new Variable("b"))
         ));
@@ -77,6 +100,12 @@ public class TypecheckerTest {
 
     @Test
     public void testStructDefWithRepeatedVariableName() {
+        /*
+         * struct A {
+         *   int b;
+         *   bool b;
+         * }
+         */
         StructDef invalidStructDef = new StructDef(new StructName("A"), List.of(
                 new Param(new IntType(), new Variable("b")),
                 new Param(new BoolType(), new Variable("b"))

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -95,16 +95,14 @@ public class TypecheckerTest {
     @Test
     public void testExpWithBinOpExp() {
         /*
-         * (!isTrue && (4 + 3 * 7 >= count - otherCount.value / 5)) || false;
+         * (false && (4 + 3 * 7 >= 4 - 3 / 5)) || true;
          */
 
-        Expression varExpOtherCount = new VariableExp(new Variable("otherCount"));
-        Variable varValue = new Variable("value");
-        DotExp dotExp = new DotExp(varExpOtherCount, varValue);
+        Expression intLiteral1 = new IntLiteralExp(1);
         Expression intLiteral5 = new IntLiteralExp(5);
-        Expression binOpDivide = new BinaryOpExp(dotExp, OperatorEnum.DIVISION, intLiteral5);
-        Expression varExpCount = new VariableExp(new Variable("count"));
-        Expression binOpMinus = new BinaryOpExp(varExpCount, OperatorEnum.MINUS, binOpDivide);
+        Expression binOpDivide = new BinaryOpExp(intLiteral1, OperatorEnum.DIVISION, intLiteral5);
+        Expression intLiteral6 = new IntLiteralExp(6);
+        Expression binOpMinus = new BinaryOpExp(intLiteral6, OperatorEnum.MINUS, binOpDivide);//
 
         Expression intLiteral3 = new IntLiteralExp(3);
         Expression intLiteral7 = new IntLiteralExp(7);
@@ -114,13 +112,12 @@ public class TypecheckerTest {
 
         Expression binOpGte = new BinaryOpExp(binOpAdd, OperatorEnum.GREATER_THAN_EQUALS, binOpMinus);
         Expression parenGteExp = new ParenExp(binOpGte);
-        Expression varIsTrue = new VariableExp(new Variable("isTrue"));
-        Expression notOpExp = new UnaryOpExp(OperatorEnum.NOT, varIsTrue);
-
-        Expression andExp = new BinaryOpExp(notOpExp, OperatorEnum.AND, parenGteExp);
         Expression falseExp = new BoolLiteralExp(false);
+
+        Expression andExp = new BinaryOpExp(falseExp, OperatorEnum.AND, parenGteExp);
+        Expression trueExp = new BoolLiteralExp(true);
         Expression parenAndExp = new ParenExp(andExp);
-        Expression orExp = new BinaryOpExp(parenAndExp, OperatorEnum.OR, falseExp);
+        Expression orExp = new BinaryOpExp(parenAndExp, OperatorEnum.OR, trueExp);
 
         Statement statement = new ExpressionStmt(orExp);
 
@@ -183,4 +180,31 @@ public class TypecheckerTest {
         testThrowsTypecheckerException(invalidProgram);
     }
 
+    @Test
+    public void testExpStmtWithBinaryOpsThrowsExceptionOnBoolInGteExp() {
+        /*
+         * (false && (4 + 3 * 7 >= true)) || true;
+         */
+        Expression trueExp2 = new BoolLiteralExp(true);
+
+        Expression intLiteral3 = new IntLiteralExp(3);
+        Expression intLiteral7 = new IntLiteralExp(7);
+        Expression binOpMult = new BinaryOpExp(intLiteral3, OperatorEnum.MULTIPLY, intLiteral7);
+        Expression intLiteral4 = new IntLiteralExp(4);
+        Expression binOpAdd = new BinaryOpExp(intLiteral4, OperatorEnum.PLUS, binOpMult);
+
+        Expression binOpGte = new BinaryOpExp(binOpAdd, OperatorEnum.GREATER_THAN_EQUALS, trueExp2);
+        Expression parenGteExp = new ParenExp(binOpGte);
+        Expression falseExp = new BoolLiteralExp(false);
+
+        Expression andExp = new BinaryOpExp(falseExp, OperatorEnum.AND, parenGteExp);
+        Expression trueExp = new BoolLiteralExp(true);
+        Expression parenAndExp = new ParenExp(andExp);
+        Expression orExp = new BinaryOpExp(parenAndExp, OperatorEnum.OR, trueExp);
+
+        Statement statement = new ExpressionStmt(orExp);
+
+        Program invalidProgram = new Program(List.of(), List.of(), List.of(statement));
+        testThrowsTypecheckerException(invalidProgram);
+    }
 }

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -350,7 +350,7 @@ public class TypecheckerTest {
         Statement returnStmtTrue = new ReturnStmt(boolTrue);
         StmtBlock funcBody = new StmtBlock(List.of(returnStmtTrue));
         FunctionDef funcDef = new FunctionDef(
-            new FunctionName("alwaysTrue"),
+            getFunctionName("alwaysTrue"),
             new ArrayList<Param>(),
             getBoolType(),
             funcBody
@@ -430,7 +430,6 @@ public class TypecheckerTest {
         testDoesNotThrowTypecheckerException(program);
     }
 
-    // Test a function with void and doesn't return anything doesn't throw an error
     @Test
     public void testVoidFunctionReturnsWithNoExp() {
         /*
@@ -445,7 +444,7 @@ public class TypecheckerTest {
         StmtBlock funcBody = new StmtBlock(List.of(assignStmt, returnStmt));
         Param paramX = new Param(getIntType(), getVariable("x"));
         FunctionDef funcDef = new FunctionDef(
-                new FunctionName("returnsNothing"),
+                getFunctionName("returnsNothing"),
                 List.of(paramX),
                 getVoidType(),
                 funcBody);
@@ -465,7 +464,7 @@ public class TypecheckerTest {
         Statement vardecStmt = new VardecStmt(getIntType(), getVariable("x"), new IntLiteralExp(0));
         StmtBlock funcBody = new StmtBlock(List.of(vardecStmt));
         FunctionDef funcDef = new FunctionDef(
-                new FunctionName("thePointOfNoReturn"),
+                getFunctionName("thePointOfNoReturn"),
                 new ArrayList<Param>(),
                 getVoidType(),
                 funcBody);
@@ -474,14 +473,32 @@ public class TypecheckerTest {
         testDoesNotThrowTypecheckerException(program);
     }
 
-    // Tests for function definitions
-    // Test a function with void type and returns something throws an error
-    // Test two function with the same name but different signatures
-    // Test two functions with the same signatures throws
-    // Test function calls function that isn't defined yet throws
-    // Test function with mutliple return statements
-    // Test function with different typed return statements throws error
     // Test recursive function
+    @Test
+    public void testRecursiveFunction() {
+        /*
+         * func andBeyond(): bool {
+         *   return andBeyond();
+         * }
+         */
+
+        CommaExp commaExp = new CommaExp(new ArrayList<Expression>());
+        FuncCallExp funcCallExp = new FuncCallExp(getFunctionName("andBeyond"), commaExp);
+        Statement returnStmt = new ReturnStmt(funcCallExp);
+        StmtBlock funcBody = new StmtBlock(List.of(returnStmt));
+        FunctionDef funcDef = new FunctionDef(
+                getFunctionName("andBeyond"),
+                new ArrayList<Param>(),
+                getBoolType(),
+                funcBody);
+
+        Program program = new Program(List.of(), List.of(funcDef), List.of());
+        testDoesNotThrowTypecheckerException(program);
+    }
+
+    // Tests for function definitions
+    // Test function with mutliple return statements (when if/else typechecking is implemented)
+    // Test function with different typed return statements throws error
 
     // private void testFunctionDefinitionWithWileLoop() {
     //     /*
@@ -900,11 +917,67 @@ public class TypecheckerTest {
                 getBoolType(),
                 funcBody);
 
-        Expression boolTrue2 = new BoolLiteralExp(true);
+        Expression boolTrue2 = new BoolLiteralExp(false);
         Statement returnStmtTrue2 = new ReturnStmt(boolTrue2);
         StmtBlock funcBody2 = new StmtBlock(List.of(returnStmtTrue2));
         FunctionDef funcDef2 = new FunctionDef(
                 getFunctionName("alwaysTrue"),
+                new ArrayList<Param>(),
+                getBoolType(),
+                funcBody2);
+
+        Program invalidProgram = new Program(List.of(), List.of(funcDef, funcDef2), List.of());
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testVoidFunctionReturnsSomethingThrowsException() {
+        /*
+         * func voidFunc(): void {
+         *   return 0;
+         * }
+         */
+
+        Expression intLiteral0 = new IntLiteralExp(0);
+        Statement returnStmt0 = new ReturnStmt(intLiteral0);
+        FunctionBody funcBody = new FunctionBody(List.of(returnStmt0));
+        FunctionDef funcDef = new FunctionDef(
+                getFunctionName("voidFunc"),
+                new ArrayList<Param>(),
+                getVoidType(),
+                funcBody);
+
+        Program invalidProgram = new Program(List.of(), List.of(funcDef), List.of());
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
+    public void testFunctionCallsNotYetDefinedFunctionThrowsException() {
+        /*
+         * func firstFunc(): bool {
+         *   return secondFunc();
+         * }
+         * 
+         * func secondFunc(): bool {
+         *   return false;
+         * }
+         */
+
+        CommaExp args = new CommaExp(new ArrayList<Expression>());
+        Expression secondFuncCallExp = new FuncCallExp(getFunctionName("secondFunc"), args);
+        Statement returnSecondFunc = new ReturnStmt(secondFuncCallExp);
+        StmtBlock funcBody = new StmtBlock(List.of(returnSecondFunc));
+        FunctionDef funcDef = new FunctionDef(
+                getFunctionName("firstFunc"),
+                new ArrayList<Param>(),
+                getBoolType(),
+                funcBody);
+
+        Expression boolTrue2 = new BoolLiteralExp(false);
+        Statement returnStmtTrue2 = new ReturnStmt(boolTrue2);
+        StmtBlock funcBody2 = new StmtBlock(List.of(returnStmtTrue2));
+        FunctionDef funcDef2 = new FunctionDef(
+                getFunctionName("secondFunc"),
                 new ArrayList<Param>(),
                 getBoolType(),
                 funcBody2);

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -1248,6 +1248,13 @@ public class TypecheckerTest {
     }
 
     @Test
+    public void testReturnStmtNotInFunctionDefThrowsException() {
+        // return;
+        Program invalidProgram = new Program(List.of(), List.of(), List.of(new ReturnStmt()));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
+    @Test
     public void testIfElseWithNonBooleanConditionThrowsException() {
         // if (7) {}
         IfElseStmt ifElseStmt = new IfElseStmt(new IntLiteralExp(7), new StmtBlock());

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -1300,10 +1300,21 @@ public class TypecheckerTest {
 
     // Integration test
 
-    @Ignore("Should be ignored until typechecker is complete.")
     @Test
     public void testTokenizeParseTypecheckProgramWithoutException() {
         String input = ResourceUtil.readProgramInputFile();
+        try {
+            List<Sourced<Token>> sourcedTokens = new Tokenizer(input).tokenize();
+            Program program = Parser.parseProgram(sourcedTokens);
+            Typechecker.typecheckProgram(program);
+        } catch (TokenizerException | ParserException | TypecheckerException ex) {
+            fail(ex.toString());
+        }
+    }
+
+    @Test
+    public void testTokenizeParseTypecheckProgram2WithoutException() {
+        String input = ResourceUtil.readProgram2InputFile();
         try {
             List<Sourced<Token>> sourcedTokens = new Tokenizer(input).tokenize();
             Program program = Parser.parseProgram(sourcedTokens);

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -733,9 +733,14 @@ public class TypecheckerTest {
     public void testTokenizeParseTypecheckInvalidProgram() {
         String input = """
                 struct A {
-                  int foo;
-                  bool foo;
-                }""";
+                    A a;
+                }
+                
+                A a = new A {
+                    a: new B {
+                        a: new B {}
+                    }
+                };""";
         try {
             List<Sourced<Token>> sourcedTokens = new Tokenizer(input).tokenize();
             Program program = Parser.parseProgram(sourcedTokens);

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -382,6 +382,29 @@ public class TypecheckerTest {
         testThrowsTypecheckerException(invalidProgram);
     }
 
+
+    @Test
+    public void testStructAllocExpWithTooFewParams() {
+        /*
+         * struct A {
+         *   A a;
+         * }
+         *
+         * new A {};
+         */
+        StructDef structDef = new StructDef(new StructName("A"), List.of(
+                new Param(new StructType(new StructName("A")), new Variable("a"))
+        ));
+
+        Expression expression = new StructAllocExp(new StructType(new StructName("A")),
+                new StructActualParams(List.of()));
+
+        Statement statement = new ExpressionStmt(expression);
+
+        Program invalidProgram = new Program(List.of(structDef), List.of(), List.of(statement));
+        testThrowsTypecheckerException(invalidProgram);
+    }
+
     @Test
     public void testStructAllocExpWithTooManyParams() {
         /*

--- a/src/test/java/refraff/typechecker/TypecheckerTest.java
+++ b/src/test/java/refraff/typechecker/TypecheckerTest.java
@@ -728,18 +728,17 @@ public class TypecheckerTest {
         }
     }
 
-    //@Ignore("Method to screenshot typechecker error messages")
+    @Ignore("Method to screenshot typechecker error messages")
     @Test
     public void testTokenizeParseTypecheckInvalidProgram() {
-        String input = "null.var;";
+        String input = """
+                struct A {
+                  int foo;
+                  bool foo;
+                }""";
         try {
             List<Sourced<Token>> sourcedTokens = new Tokenizer(input).tokenize();
             Program program = Parser.parseProgram(sourcedTokens);
-
-            ExpressionStmt expressionStmt = (ExpressionStmt) program.getStatements().get(0);
-            DotExp dotExp = (DotExp) expressionStmt.getExpression();
-            System.out.println(dotExp.getLeftExp().getExpressionType());
-
             Typechecker.typecheckProgram(program);
         } catch (TokenizerException | ParserException | TypecheckerException ex) {
             fail(ex.toString());

--- a/src/test/java/refraff/util/ResourceUtil.java
+++ b/src/test/java/refraff/util/ResourceUtil.java
@@ -11,6 +11,7 @@ public class ResourceUtil {
     private static final String TEST_DIRECTORY = "src/test/resources";
 
     private static final String PROGRAM_FILE = "program.txt";
+    private static final String PROGRAM2_FILE = "program2.txt";
 
     public static String readInputFile(String filePath) {
         File file = new File(TEST_DIRECTORY, filePath);
@@ -34,5 +35,9 @@ public class ResourceUtil {
 
     public static String readProgramInputFile() {
         return readInputFile(PROGRAM_FILE);
+    }
+
+    public static String readProgram2InputFile() {
+        return readInputFile(PROGRAM2_FILE);
     }
 }

--- a/src/test/java/refraff/util/ResourceUtil.java
+++ b/src/test/java/refraff/util/ResourceUtil.java
@@ -24,6 +24,8 @@ public class ResourceUtil {
                     stringBuffer.append(scanner.nextLine());
                     stringBuffer.append('\n');
                 }
+
+                stringBuffer.deleteCharAt(stringBuffer.length() - 1);
             }
         });
 

--- a/src/test/resources/program2.txt
+++ b/src/test/resources/program2.txt
@@ -1,0 +1,42 @@
+struct Node {
+  int value;
+  Node rest;
+}
+
+func length(Node list): int {
+  int retval = 0;
+  while (list != null) {
+     retval = retval + 1;
+     list = list.rest;
+  }
+  return retval;
+}
+
+func printLength(Node list): void {
+    println(length(list));
+}
+
+func equals(Node list1, Node list2): bool {
+    while (list1 != null && list2 != null)
+        if (list1.value != list2.value)
+            return false;
+
+    return list1 == null && list2 == null;
+}
+
+Node list =
+  new Node {
+    value: 0,
+    rest: new Node {
+      value: 1,
+      rest: new Node {
+        value: 2,
+        rest: null
+      }
+    }
+  };
+
+Node list2 = null;
+
+printLength(list);
+println(equals(list, list2));


### PR DESCRIPTION
I believe that the typechecker is as tested as it could be. This pull request has our changes from pretty much the entire typechecking process (including your overloaded function defs branch). For some reason, I didn't make my changes in my own branch and merge it into `typechecker`. I'm getting into bad habits in another class where I'm constantly hotfixing things and working on different branches at the same time. 

A summary of some of the changes that I just made:

- While statement typechecking
- Break statement typechecking
- If/else statement typechecking
- println statement typechecking
- return statement bug fix
  - Problem:
    - Old code tried to call all the return statements through a loop in function body
    - But if a return statement was in a while, or an if/else, then it wouldn't be tracked properly
  - Added a global `withinFunctionDef` to make sure we're typechecking a function when we read a return
  - Added a global `allReturnTypesInThisFunction` to add the return type to
  -  Check global `allReturnTypesInThisFunction` after we've processed the whole function body
- Updated some methods to use `hasTypeEquality` over `getClass().equals(otherClass)`
  - This would fix a bug where some StructType for struct A would be marked as equal to StructType for struct B
- Added comprehensive bin op testing
- Added other missing test cases to improve our coverage

Unfortunately, the percent of typechecking is only at 85%. This is due to Jacoco not properly realizing that we have thrown an exception, and that the line should be marked as visited. I don't think it is possible to increase coverage for other code lines.

I think that the typechecker is now ready for submission, when that due date comes along.